### PR TITLE
Implement encryption.

### DIFF
--- a/src/jar.rs
+++ b/src/jar.rs
@@ -309,6 +309,8 @@ mod secure {
         hmac.finalize()
     }
 
+    // Implementation details were taken from Rails. See
+    // https://github.com/rails/rails/blob/master/activesupport/lib/active_support/message_encryptor.rb#L57
     pub fn encrypt_and_sign(root: &Root, mut cookie: Cookie) -> Cookie {
         let encrypted_data = encrypt_data(root, cookie.value.as_slice());
         cookie.value = encrypted_data;


### PR DESCRIPTION
Cookies encryption is now implemented. Code was reorganized to allow better functions reuse.

One big thing we need to discuss here is the `key` field. To encrypt a cookie we need a 32-bit key and we can:
1. Enforce clients to provide at least 32-bit key (as implemented).
2. Build a long key using a short one using repeat strategy. I think it's less secure.
