### PR TITLE
Add semicolon after macros

### DIFF
--- a/src/jar.rs
+++ b/src/jar.rs
@@ -455,7 +455,7 @@ mod test {
             $c.add(cookie);
             assert!($c.$secure().find("test").is_none());
         })
-    )
+    );
 
     #[test]
     fn signed() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl Cookie {
     pub fn parse(s: &str) -> Result<Cookie, ()> {
         macro_rules! try_option( ($e:expr) => (
             match $e { Some(s) => s, None => return Err(()) }
-        ) )
+        ) );
 
         let mut c = Cookie::new(String::new(), String::new());
         let mut pairs = s.trim().split(';');


### PR DESCRIPTION
Fixes broken build for rust nightly
