### PR TITLE
OpenSSL 0.4 -> 0.5, new IO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ similar to Rails' cookie jar.
 """
 
 [dependencies]
-openssl = "0.4"
+openssl = "0.5"
 url = "0.2"
 time = "0.1"
 rustc-serialize = "0.3"

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -301,6 +301,7 @@ mod secure {
     use {Cookie};
     use openssl::crypto::{hmac, hash, memcmp, symm};
     use serialize::hex::{ToHex, FromHex};
+    use std::io::prelude::{Write};
 
     pub const MIN_KEY_LEN: usize = 32;
 
@@ -349,7 +350,7 @@ mod secure {
 
     fn dosign(root: &Root, val: &str) -> Vec<u8> {
         let mut hmac = hmac::HMAC::new(hash::Type::SHA1, root.key.as_slice());
-        let _ = hmac.write_all(val.as_bytes());
+        let _ = hmac.write(val.as_bytes()); // FIXME: shouldn't maybe ignore the result - amount of bytes written?
         hmac.finish()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core, collections, old_io)]
+#![feature(core, collections, io)]
 #![cfg_attr(test, deny(warnings))]
 
 extern crate url;


### PR DESCRIPTION
Bump the OpenSSL version to 0.5, since some other projects (handlebars-iron) have a dependency to that, and cargo can't mix the versions. OpenSSL uses the new IO, so updated that too.

FIXME: OpenSSL now returns the amount of bytes written to HMAC. Should we continue ignoring it, or check?