### PR TITLE
upgrade openssl to v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ similar to Rails' cookie jar.
 """
 
 [dependencies]
-openssl = "0.5"
+openssl = "0.6.0"
 url = "0.2"
 time = "0.1"
 rustc-serialize = "0.3"


### PR DESCRIPTION
upgrade openssl so that framework like nickel.rs can build pass.