### PR TITLE
Add no-default-features, providing just the parsing functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,14 @@ encrypted, signed, and permanent cookie chars composed together in amanner
 similar to Rails' cookie jar.
 """
 
+[features]
+default = ["openssl"]
+
 [dependencies]
-openssl = "0.6.0"
 url = "0.2"
 time = "0.1"
 rustc-serialize = "0.3"
+
+[dependencies.openssl]
+version = "0.6.0"
+optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate url;
 extern crate time;
+#[cfg(feature="openssl")]
 extern crate openssl;
 extern crate rustc_serialize;
 
@@ -11,8 +12,9 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
 
+#[cfg(feature="openssl")]
 pub use jar::CookieJar;
-
+#[cfg(feature="openssl")]
 mod jar;
 
 #[derive(PartialEq, Clone, Debug)]


### PR DESCRIPTION
It is not practical for some packages to pull a dependency on openssl,
but they want to use cookie parsing, so compiling with
--no-default-features removes the cookie jar and with this the dependency
on openssl.

As discussed in hyperium/hyper#433