### PR TITLE
include jar even if secure feature is disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ similar to Rails' cookie jar.
 """
 
 [features]
-default = ["openssl", "rustc-serialize"]
+default = ["secure"]
+secure = ["openssl", "rustc-serialize"]
 
 [dependencies]
 url = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
 
-#[cfg(feature = "default")]
 pub use jar::CookieJar;
-#[cfg(feature = "default")]
 mod jar;
 
 #[derive(PartialEq, Clone, Debug)]


### PR DESCRIPTION
The `secure` module and the `signed` and `encrypted` methods are the
only parts of `jar` that depend on `openssl`, so this adds all the other
parts of jar to be used even without those crates.