### PR TITLE
Add RuctcEncdoable and RustcDecodable to derive attribute for Cookie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
   - cargo build --verbose
   - cargo test --verbose --no-default-features
   - cargo test --verbose
+  - cargo test --verbose --features serialize-rustc
   - rustdoc --test README.md -L target
   - cargo doc --no-deps
 after_success: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ similar to Rails' cookie jar.
 
 [features]
 default = ["secure"]
+serialize-rustc = ["rustc-serialize", "time/rustc-serialize"]
 secure = ["openssl", "rustc-serialize"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate url;
 extern crate time;
+#[cfg(feature = "serialize-rustc")] extern crate rustc_serialize;  
 
 use std::ascii::AsciiExt;
 use std::collections::BTreeMap;
@@ -13,6 +14,7 @@ pub use jar::CookieJar;
 mod jar;
 
 #[derive(PartialEq, Clone, Debug)]
+#[cfg_attr(feature = "serialize-rustc", derive(RustcEncodable, RustcDecodable))]
 pub struct Cookie {
     pub name: String,
     pub value: String,


### PR DESCRIPTION
It was recommended in this pull [request](https://github.com/servo/servo/pull/10800) for servo that I placed the derive attribute for the RustcEncodable and RustcDecodable traits for the cookie_rs:Cookie to avoid encoding and decoding manually.  I noticed in the time library that the  #[cfg] attribute is used to make the encodable/decodable attribute optional.  If you would like me to add the #[cfg] attribute just let me know!

Edit: Actually I went ahead and added the #[cfg] attribute because rustc-serialize is marked as optional in Cargo.toml