### PR TITLE
Implement serde serialization for Cookie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - cargo test --verbose --no-default-features
   - cargo test --verbose
   - cargo test --verbose --features serialize-rustc
+  - cargo test --verbose --features serialize-serde
   - rustdoc --test README.md -L target
   - cargo doc --no-deps
 after_success: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,14 @@ similar to Rails' cookie jar.
 default = ["secure"]
 serialize-rustc = ["rustc-serialize", "time/rustc-serialize"]
 secure = ["openssl", "rustc-serialize"]
+serialize-serde = ["serde"]
 
 [dependencies]
 url = "1.0"
 time = "0.1"
 rustc-serialize = { version = "0.3", optional = true }
 openssl = { version = "0.7.0", optional = true }
+serde = { version = "0.7.5", optional = true }
+
+[dev-dependencies]
+serde_json = "0.7.0"


### PR DESCRIPTION
Implement `serde::Serialize` and `serde::Deserialize` for `Cookie` and add it behind the `serialize-serde` feature. This is largely done to allow for `Cookie` to be sent across servo `ipc-channel`s.

Critiques are very welcome. There might be a better way of doing this.

NB: `Cookie::custom` was not included in this PR.

Related to: servo/servo#10826

CC @asajeffrey

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexcrichton/cookie-rs/48)
<!-- Reviewable:end -->
