### PR TITLE
Fix handling of cookies with ; in value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ impl<'a> fmt::Display for AttrVal<'a> {
         let AttrVal(ref attr, ref val) = *self;
         write!(f, "{}={}", attr, url::percent_encoding::percent_encode(
             val.as_bytes(),
-            url::percent_encoding::DEFAULT_ENCODE_SET)
+            url::percent_encoding::USERINFO_ENCODE_SET)
         )
     }
 }
@@ -332,7 +332,7 @@ mod tests {
 
     #[cfg(feature = "serialize-serde")]
     #[test]
-    fn test_serialize_semicolons() {
+    fn test_serialize_odd_characters() {
         #[cfg(feature = "serialize-serde")] extern crate serde_json;
 
         use super::Cookie;
@@ -344,7 +344,7 @@ mod tests {
         custom.insert("arm".to_string(), "x0".to_string());
         let original = Cookie {
             name: "test".to_owned(),
-            value: "hello;world".to_owned(),
+            value: "^start/foo=bar\\s,name@place:[test]|hello;world".to_owned(),
             expires: Some(time::strptime("Tue, 15 Jun 2016 20:00:00 UTC",
                                          "%a, %d %b %Y %H:%M:%S %Z").unwrap()),
             max_age: Some(42),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,4 +329,36 @@ mod tests {
 
         assert_eq!(original, roundtrip);
     }
+
+    #[cfg(feature = "serialize-serde")]
+    #[test]
+    fn test_serialize_semicolons() {
+        #[cfg(feature = "serialize-serde")] extern crate serde_json;
+
+        use super::Cookie;
+        use time;
+        use std::collections::BTreeMap;
+
+        let mut custom = BTreeMap::new();
+        custom.insert("x86".to_string(), "rdi".to_string());
+        custom.insert("arm".to_string(), "x0".to_string());
+        let original = Cookie {
+            name: "test".to_owned(),
+            value: "hello;world".to_owned(),
+            expires: Some(time::strptime("Tue, 15 Jun 2016 20:00:00 UTC",
+                                         "%a, %d %b %Y %H:%M:%S %Z").unwrap()),
+            max_age: Some(42),
+            domain: Some("example.com".to_owned()),
+            path: Some("/".to_owned()),
+            secure: true,
+            httponly: false,
+            custom: custom
+        };
+
+        let serialized = serde_json::to_string(&original).unwrap();
+
+        let roundtrip: Cookie = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(original, roundtrip);
+    }
 }


### PR DESCRIPTION
I encountered an issue when serialising cookies so that they can be reused between invocations of a tool I'm writing. If the cookie value contains a percent encoded `;` it is serialised with percent encodings resolved. When the cookie is read back in the value is truncated after the first `;`. I'm not quite sure what the fix is so I added a failing test in this PR to demonstrate the issue. It seems this may be related to https://github.com/alexcrichton/cookie-rs/issues/40.

Sample test run:

```
cargo test --features serialize-serde
     Running target/debug/cookie-00ccfac4debcd91d

running 8 tests
test tests::odd_characters ... ok
test tests::pair ... ok
test jar::test::simple ... ok
test jar::test::permanent ... ok
test tests::parse ... ok
test tests::test_serialize ... ok
test tests::test_serialize_semicolons ... FAILED
test jar::test::short_key ... ok

failures:

---- tests::test_serialize_semicolons stdout ----
	thread 'tests::test_serialize_semicolons' panicked at 'assertion failed: `(left == right)` (left: `Cookie { name: "test", value: "hello;world", expires: Some(Tm { tm_sec: 0, tm_min: 0, tm_hour: 20, tm_mday: 15, tm_mon: 5, tm_year: 116, tm_wday: 2, tm_yday: 0, tm_isdst: 0, tm_utcoff: 0, tm_nsec: 0 }), max_age: Some(42), domain: Some("example.com"), path: Some("/"), secure: true, httponly: false, custom: {"arm": "x0", "x86": "rdi"} }`, right: `Cookie { name: "test", value: "hello", expires: Some(Tm { tm_sec: 0, tm_min: 0, tm_hour: 20, tm_mday: 15, tm_mon: 5, tm_year: 116, tm_wday: 2, tm_yday: 0, tm_isdst: 0, tm_utcoff: 0, tm_nsec: 0 }), max_age: Some(42), domain: Some("example.com"), path: Some("/"), secure: true, httponly: false, custom: {"arm": "x0", "x86": "rdi"} }`)', src/lib.rs:362
note: Run with `RUST_BACKTRACE=1` for a backtrace.


failures:
    tests::test_serialize_semicolons

test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured

error: test failed
```

**Note:** value before `value: "hello;world"` and value after: `value: "hello" `