### PR TITLE
Bump version to 0.4.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "cookie"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cookie-rs"
 documentation = "http://alexcrichton.com/cookie-rs"


### PR DESCRIPTION
As far as I can tell 9e4baf40ebe59b025b7e9a63b50dcc0460dc78a5 avoided any issues with breaking changes, so a minor version bump should be acceptable.