### PR TITLE
Overhaul Cookie Crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ script:
   - cargo build --verbose
   - cargo test --verbose --no-default-features
   - cargo test --verbose
-  - cargo test --verbose --features serialize-rustc
-  - cargo test --verbose --features serialize-serde
+  - cargo test --verbose --features percent-encode
   - cargo test --verbose --features secure
+  - cargo test --verbose --all-features
   - rustdoc --test README.md -L target
   - cargo doc --no-deps
 after_success:
@@ -20,7 +20,6 @@ after_success:
 env:
   global:
     secure: "TyMGH+sbPmKs9lKCziKShxWr3G6im0owEchVrbUChWnQIQv1WydXftFoEoUsVl6qZspjehWK1b1AsnIgCXK0HtEi4DnqLsxs0s36bOjfg5yHBT/pETTr6kcq7KAL4Be4GmI331k6gT1Oi0TPFp7Sg9xpiWsQqKIHA5Szk2wpFQ8="
-
 
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "cookie"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Sergio Benitez <sb@sergio.bz>"]
-version = "0.5.1"
+version = "0.6.0"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cookie-rs"
 documentation = "http://docs.rs/cookie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 
 name = "cookie"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+authors = ["Alex Crichton <alex@alexcrichton.com>", "Sergio Benitez <sb@sergio.bz>"]
 version = "0.5.1"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cookie-rs"
-documentation = "http://alexcrichton.com/cookie-rs"
+documentation = "http://docs.rs/cookie"
 description = """
 Crate for parsing HTTP cookie headers and managing a cookie jar. Supports
 encrypted, signed, and permanent cookie chars composed together in a manner
@@ -14,16 +14,11 @@ similar to Rails' cookie jar.
 
 [features]
 default = ["secure"]
-serialize-rustc = ["rustc-serialize", "time/rustc-serialize"]
 secure = ["openssl", "rustc-serialize"]
-serialize-serde = ["serde"]
+percent-encode = ["url"]
 
 [dependencies]
-url = "1.0"
 time = "0.1"
-rustc-serialize = { version = "0.3", optional = true }
+url = { version = "1.0", optional = true }
 openssl = { version = "0.9.0", optional = true }
-serde = { version = "0.8", optional = true }
-
-[dev-dependencies]
-serde_json = "0.8.0"
+rustc-serialize = { version = "0.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![Build Status](https://travis-ci.org/alexcrichton/cookie-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/cookie-rs)
 
-[Documentation](http://alexcrichton.com/cookie-rs/cookie/index.html)
+[Documentation](http://docs.rs/cookie-rs)
 
 A library for parsing HTTP cookies and managing cookie jars
 
 ```toml
 # Cargo.toml
 [dependencies]
-cookie = "0.4"
+cookie = "0.6"
 ```
 
 # License

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,208 @@
+use std::borrow::Cow;
+
+use time::{Tm, Duration};
+
+use ::Cookie;
+
+/// Structure that follows the builder pattern for building `Cookie` structs.
+///
+/// To construct a cookie:
+///
+///   1. Call [Cookie::build](struct.Cookie.html#method.build) to start building.
+///   2. Use any of the builder methods to set fields in the cookie.
+///   3. Call [finish](#method.finish) to retrieve the built cookie.
+///
+/// # Example
+///
+/// ```rust
+/// # extern crate cookie;
+/// extern crate time;
+///
+/// use cookie::Cookie;
+/// use time::Duration;
+///
+/// # fn main() {
+/// let cookie: Cookie = Cookie::build("name", "value")
+///     .domain("www.rust-lang.org")
+///     .path("/")
+///     .secure(true)
+///     .http_only(true)
+///     .max_age(Duration::days(1))
+///     .finish();
+/// # }
+/// ```
+///
+#[derive(Debug, Clone)]
+pub struct CookieBuilder {
+    /// The cookie being built.
+    cookie: Cookie<'static>,
+}
+
+impl CookieBuilder {
+    /// Creates a new `CookieBuilder` instance from the given name and value.
+    ///
+    /// This method is typically called indirectly via
+    /// [Cookie::build](struct.Cookie.html#method.build).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::build("foo", "bar").finish();
+    /// assert_eq!(c.name_value(), ("foo", "bar"));
+    /// ```
+    #[inline(always)]
+    pub fn new<N, V>(name: N, value: V) -> CookieBuilder
+        where N: Into<Cow<'static, str>>,
+              V: Into<Cow<'static, str>>
+    {
+        CookieBuilder { cookie: Cookie::new(name, value) }
+    }
+
+    /// Sets the `expires` field in the cookie being built.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate cookie;
+    /// extern crate time;
+    ///
+    /// use cookie::Cookie;
+    ///
+    /// # fn main() {
+    /// let c = Cookie::build("foo", "bar")
+    ///     .expires(time::now())
+    ///     .finish();
+    ///
+    /// assert!(c.expires().is_some());
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn expires(mut self, when: Tm) -> CookieBuilder {
+        self.cookie.set_expires(when);
+        self
+    }
+
+    /// Sets the `max_age` field in the cookie being built.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate cookie;
+    /// extern crate time;
+    /// use time::Duration;
+    ///
+    /// use cookie::Cookie;
+    ///
+    /// # fn main() {
+    /// let c = Cookie::build("foo", "bar")
+    ///     .max_age(Duration::minutes(30))
+    ///     .finish();
+    ///
+    /// assert_eq!(c.max_age(), Some(Duration::seconds(30 * 60)));
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn max_age(mut self, value: Duration) -> CookieBuilder {
+        self.cookie.set_max_age(value);
+        self
+    }
+
+    /// Sets the `domain` field in the cookie being built.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::build("foo", "bar")
+    ///     .domain("www.rust-lang.org")
+    ///     .finish();
+    ///
+    /// assert_eq!(c.domain(), Some("www.rust-lang.org"));
+    /// ```
+    #[inline(always)]
+    pub fn domain<D: Into<Cow<'static, str>>>(mut self, value: D) -> CookieBuilder {
+        self.cookie.set_domain(value);
+        self
+    }
+
+    /// Sets the `path` field in the cookie being built.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::build("foo", "bar")
+    ///     .path("/")
+    ///     .finish();
+    ///
+    /// assert_eq!(c.path(), Some("/"));
+    /// ```
+    #[inline(always)]
+    pub fn path<P: Into<Cow<'static, str>>>(mut self, path: P) -> CookieBuilder {
+        self.cookie.set_path(path);
+        self
+    }
+
+    /// Sets the `secure` field in the cookie being built.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::build("foo", "bar")
+    ///     .secure(true)
+    ///     .finish();
+    ///
+    /// assert_eq!(c.secure(), true);
+    /// ```
+    #[inline(always)]
+    pub fn secure(mut self, value: bool) -> CookieBuilder {
+        self.cookie.set_secure(value);
+        self
+    }
+
+    /// Sets the `http_only` field in the cookie being built.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::build("foo", "bar")
+    ///     .http_only(true)
+    ///     .finish();
+    ///
+    /// assert_eq!(c.http_only(), true);
+    /// ```
+    #[inline(always)]
+    pub fn http_only(mut self, value: bool) -> CookieBuilder {
+        self.cookie.set_http_only(value);
+        self
+    }
+
+    /// Finishes building and returns the built `Cookie`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::build("foo", "bar")
+    ///     .domain("crates.io")
+    ///     .path("/")
+    ///     .finish();
+    ///
+    /// assert_eq!(c.name_value(), ("foo", "bar"));
+    /// assert_eq!(c.domain(), Some("crates.io"));
+    /// assert_eq!(c.path(), Some("/"));
+    /// ```
+    #[inline(always)]
+    pub fn finish(self) -> Cookie<'static> {
+        self.cookie
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -52,7 +52,6 @@ impl CookieBuilder {
     /// let c = Cookie::build("foo", "bar").finish();
     /// assert_eq!(c.name_value(), ("foo", "bar"));
     /// ```
-    #[inline(always)]
     pub fn new<N, V>(name: N, value: V) -> CookieBuilder
         where N: Into<Cow<'static, str>>,
               V: Into<Cow<'static, str>>
@@ -78,7 +77,7 @@ impl CookieBuilder {
     /// assert!(c.expires().is_some());
     /// # }
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn expires(mut self, when: Tm) -> CookieBuilder {
         self.cookie.set_expires(when);
         self
@@ -103,7 +102,7 @@ impl CookieBuilder {
     /// assert_eq!(c.max_age(), Some(Duration::seconds(30 * 60)));
     /// # }
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn max_age(mut self, value: Duration) -> CookieBuilder {
         self.cookie.set_max_age(value);
         self
@@ -122,7 +121,6 @@ impl CookieBuilder {
     ///
     /// assert_eq!(c.domain(), Some("www.rust-lang.org"));
     /// ```
-    #[inline(always)]
     pub fn domain<D: Into<Cow<'static, str>>>(mut self, value: D) -> CookieBuilder {
         self.cookie.set_domain(value);
         self
@@ -141,7 +139,6 @@ impl CookieBuilder {
     ///
     /// assert_eq!(c.path(), Some("/"));
     /// ```
-    #[inline(always)]
     pub fn path<P: Into<Cow<'static, str>>>(mut self, path: P) -> CookieBuilder {
         self.cookie.set_path(path);
         self
@@ -160,7 +157,7 @@ impl CookieBuilder {
     ///
     /// assert_eq!(c.secure(), true);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn secure(mut self, value: bool) -> CookieBuilder {
         self.cookie.set_secure(value);
         self
@@ -179,7 +176,7 @@ impl CookieBuilder {
     ///
     /// assert_eq!(c.http_only(), true);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn http_only(mut self, value: bool) -> CookieBuilder {
         self.cookie.set_http_only(value);
         self
@@ -201,7 +198,7 @@ impl CookieBuilder {
     /// assert_eq!(c.domain(), Some("crates.io"));
     /// assert_eq!(c.path(), Some("/"));
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn finish(self) -> Cookie<'static> {
         self.cookie
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,8 @@ pub use parse::ParseError;
 pub use builder::CookieBuilder;
 pub use jar::CookieJar;
 
-#[doc(hidden)]
 #[derive(Debug, Clone)]
-pub enum CookieStr {
+enum CookieStr {
     /// An string derived from indexes (start, end).
     Indexed(usize, usize),
     /// A string derived from a concrete string.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,6 @@ impl Cookie<'static> {
     /// let cookie = Cookie::new("name", "value");
     /// assert_eq!(cookie.name_value(), ("name", "value"));
     /// ```
-    #[inline(always)]
     pub fn new<N, V>(name: N, value: V) -> Cookie<'static>
         where N: Into<Cow<'static, str>>,
               V: Into<Cow<'static, str>>
@@ -205,7 +204,6 @@ impl Cookie<'static> {
     /// let c = Cookie::build("foo", "bar").finish();
     /// assert_eq!(c.name_value(), ("foo", "bar"));
     /// ```
-    #[inline(always)]
     pub fn build<N, V>(name: N, value: V) -> CookieBuilder
         where N: Into<Cow<'static, str>>,
               V: Into<Cow<'static, str>>
@@ -227,7 +225,6 @@ impl<'c> Cookie<'c> {
     /// assert_eq!(c.name_value(), ("foo", "bar%20baz"));
     /// assert_eq!(c.http_only(), true);
     /// ```
-    #[inline]
     pub fn parse<S>(s: S) -> Result<Cookie<'c>, ParseError>
         where S: Into<Cow<'c, str>>
     {
@@ -247,7 +244,6 @@ impl<'c> Cookie<'c> {
     /// assert_eq!(c.name_value(), ("foo", "bar baz"));
     /// assert_eq!(c.http_only(), true);
     /// ```
-    #[inline]
     #[cfg(feature = "percent-encode")]
     pub fn parse_encoded<S>(s: S) -> Result<Cookie<'c>, ParseError>
         where S: Into<Cow<'c, str>>
@@ -345,7 +341,7 @@ impl<'c> Cookie<'c> {
     /// let c = Cookie::new("name", "value");
     /// assert_eq!(c.name_value(), ("name", "value"));
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn name_value(&self) -> (&str, &str) {
         (self.name(), self.value())
     }
@@ -476,7 +472,6 @@ impl<'c> Cookie<'c> {
     /// c.set_name("foo");
     /// assert_eq!(c.name(), "foo");
     /// ```
-    #[inline(always)]
     pub fn set_name<N: Into<Cow<'static, str>>>(&mut self, name: N) {
         self.name = CookieStr::Concrete(name.into())
     }
@@ -494,7 +489,6 @@ impl<'c> Cookie<'c> {
     /// c.set_value("bar");
     /// assert_eq!(c.value(), "bar");
     /// ```
-    #[inline(always)]
     pub fn set_value<V: Into<Cow<'static, str>>>(&mut self, value: V) {
         self.value = CookieStr::Concrete(value.into())
     }
@@ -512,7 +506,7 @@ impl<'c> Cookie<'c> {
     /// c.set_http_only(true);
     /// assert_eq!(c.http_only(), true);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn set_http_only(&mut self, value: bool) {
         self.http_only = value;
     }
@@ -530,7 +524,7 @@ impl<'c> Cookie<'c> {
     /// c.set_secure(true);
     /// assert_eq!(c.secure(), true);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn set_secure(&mut self, value: bool) {
         self.secure = value;
     }
@@ -554,7 +548,7 @@ impl<'c> Cookie<'c> {
     /// assert_eq!(c.max_age(), Some(Duration::hours(10)));
     /// # }
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn set_max_age(&mut self, value: Duration) {
         self.max_age = Some(value);
     }
@@ -572,7 +566,6 @@ impl<'c> Cookie<'c> {
     /// c.set_path("/");
     /// assert_eq!(c.path(), Some("/"));
     /// ```
-    #[inline(always)]
     pub fn set_path<P: Into<Cow<'static, str>>>(&mut self, path: P) {
         self.path = Some(CookieStr::Concrete(path.into()));
     }
@@ -590,7 +583,6 @@ impl<'c> Cookie<'c> {
     /// c.set_domain("rust-lang.org");
     /// assert_eq!(c.domain(), Some("rust-lang.org"));
     /// ```
-    #[inline(always)]
     pub fn set_domain<D: Into<Cow<'static, str>>>(&mut self, domain: D) {
         self.domain = Some(CookieStr::Concrete(domain.into()));
     }
@@ -616,7 +608,7 @@ impl<'c> Cookie<'c> {
     /// assert!(c.expires().is_some())
     /// # }
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn set_expires(&mut self, time: Tm) {
         self.expires = Some(time);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,19 @@
-#![deny(missing_docs)]
-#![doc(html_root_url = "http://alexcrichton.com/cookie-rs")]
-#![cfg_attr(test, deny(warnings))]
+// #![deny(missing_docs)]
+// #![cfg_attr(test, deny(warnings))]
 
-//! HTTP Cookie parsing and Cookie Jar management
+//! HTTP Cookie parsing and Cookie Jar management.
 //!
-//! Usage:
+//! This crates provides the [Cookie](struct.Cookie.html) type, which directly
+//! maps to an HTTP cookie, and the [CookieJar](struct.CookieJar.html) type,
+//! which allows for simple management of many cookies as well as encryption and
+//! signing of cookies for session management.
 //!
-//! add the following to the `[dependencies]` section of
-//! your `Cargo.toml`:
+//! # Usage
+//!
+//! Add the following to the `[dependencies]` section of your `Cargo.toml`:
 //!
 //! ```ignore
-//! cookie = "0.4"
+//! cookie = "0.6"
 //! ```
 //!
 //! Then add the following line to your crate root:
@@ -18,410 +21,729 @@
 //! ```ignore
 //! extern crate cookie;
 //! ```
+//!
+//! # Features
+//!
+//! This crates can be configured at compile-time through the following Cargo
+//! features:
+//!
+//!
+//! * **secure** (enabled by default)
+//!
+//!   Enables signing and encryption of cookies.
+//!
+//!   When this feature is enabled, signed and encrypted cookies jars will
+//!   encrypt and/or sign any cookies added to them. When this feature is
+//!   disabled, those cookies will be added in plaintext.
+//!
+//! * **percent-encode** (disabled by default)
+//!
+//!   Enables percent encoding and decoding of names and values in cookies.
+//!
+//!   When this feature is enabled, cookie name and values will be
+//!   percent-encoded when `to_string` is called on a `Cookie` and
+//!   percent-decoded when a cookie is parsed using `parse` or `parse_static`.
+//!   When this feature is disabled, cookie names and values will not be
+//!   modified in any way.
+//!
+//! You can enable features via the `Cargo.toml` file:
+//!
+//! ```ignore
+//! [dependencies.cookie]
+//! features = ["secure", "percent-encode"]
+//! ```
 
-extern crate url;
 extern crate time;
-#[cfg(feature = "serialize-rustc")] extern crate rustc_serialize;
-#[cfg(feature = "serialize-serde")] extern crate serde;
+#[cfg(feature = "percent-encode")]
+extern crate url;
 
+mod builder;
+mod jar;
+mod parse;
+
+use std::borrow::Cow;
 use std::ascii::AsciiExt;
-use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
 
-#[cfg(feature = "serialize-serde")] use serde::{Serialize, Deserialize};
+use time::{Tm, Duration};
+#[cfg(feature = "percent-encode")]
+use url::percent_encoding::{USERINFO_ENCODE_SET, percent_encode};
 
+use parse::parse_cookie;
+pub use parse::ParseError;
+
+pub use builder::CookieBuilder;
 pub use jar::CookieJar;
-mod jar;
 
-/// Holds all the data for a single cookie
-#[derive(PartialEq, Clone, Debug)]
-#[cfg_attr(feature = "serialize-rustc", derive(RustcEncodable, RustcDecodable))]
-pub struct Cookie {
-    #[allow(missing_docs)]
-    pub name: String,
-    #[allow(missing_docs)]
-    pub value: String,
-    #[allow(missing_docs)]
-    pub expires: Option<time::Tm>,
-    #[allow(missing_docs)]
-    pub max_age: Option<u64>,
-    #[allow(missing_docs)]
-    pub domain: Option<String>,
-    #[allow(missing_docs)]
-    pub path: Option<String>,
-    #[allow(missing_docs)]
-    pub secure: bool,
-    #[allow(missing_docs)]
-    pub httponly: bool,
-    #[allow(missing_docs)]
-    pub custom: BTreeMap<String, String>,
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub enum CookieStr {
+    /// An string derived from indexes (start, end).
+    Indexed(usize, usize),
+    /// A string derived from a concrete string.
+    Concrete(Cow<'static, str>),
 }
 
-/// Crate-level error type used to indicate a problem with parsing
-#[derive(Debug)]
-pub struct Error(());
+impl CookieStr {
+    /// Whether this string is derived from indexes or not.
+    pub fn is_indexed(&self) -> bool {
+        match *self {
+            CookieStr::Indexed(..) => true,
+            CookieStr::Concrete(..) => false,
+        }
+    }
 
-impl Cookie {
-    /// Creates a new `Cookie` instance from key and value strings
+    /// Retrieves the string `self` corresponds to. If `self` is derived from
+    /// indexes, the corresponding subslice of `string` is returned. Otherwise,
+    /// the concrete string is returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` is an indexed string and `string` is None.
+    pub fn to_str<'s>(&'s self, string: Option<&'s Cow<str>>) -> &'s str {
+        if self.is_indexed() && string.is_none() {
+            panic!("Cannot convert indexed str to str without base string!")
+        }
+
+        match *self {
+            CookieStr::Indexed(i, j) => &string.unwrap()[i..j],
+            CookieStr::Concrete(ref cstr) => &*cstr,
+        }
+    }
+}
+
+/// Representation of an HTTP cookie.
+///
+/// # Constructing a `Cookie`
+///
+/// To construct a cookie with only a name/value, use the [new](#method.new)
+/// method:
+///
+/// ```rust
+/// use cookie::Cookie;
+///
+/// let cookie = Cookie::new("name", "value");
+/// assert_eq!(&cookie.to_string(), "name=value");
+/// ```
+///
+/// To construct more elaborate cookies, use the [build](#method.build) method
+/// and [CookieBuilder](struct.CookieBuilder.html) methods:
+///
+/// ```rust
+/// use cookie::Cookie;
+///
+/// let cookie = Cookie::build("name", "value")
+///     .domain("www.rust-lang.org")
+///     .path("/")
+///     .secure(true)
+///     .http_only(true)
+///     .finish();
+/// ```
+#[derive(Debug, Clone)]
+pub struct Cookie<'c> {
+    /// Storage for the cookie string. Only used if this structure was derived
+    /// from a string that was subsequently parsed.
+    cookie_string: Option<Cow<'c, str>>,
+    /// The cookie's name.
+    name: CookieStr,
+    /// The cookie's value.
+    value: CookieStr,
+    /// The cookie's experiation, if any.
+    expires: Option<Tm>,
+    /// The cookie's maximum age, if any.
+    max_age: Option<Duration>,
+    /// The cookie's domain, if any.
+    domain: Option<CookieStr>,
+    /// The cookie's path domain, if any.
+    path: Option<CookieStr>,
+    /// Whether this cookie was marked secure.
+    secure: bool,
+    /// Whether this cookie was marked httponly.
+    http_only: bool,
+}
+
+impl Cookie<'static> {
+    /// Creates a new `Cookie` with the given name and value.
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust
     /// use cookie::Cookie;
     ///
-    /// let c = Cookie::new("foo".into(), "bar".into());
-    /// assert_eq!(c.name, "foo");
-    /// assert_eq!(c.value, "bar");
+    /// let cookie = Cookie::new("name", "value");
+    /// assert_eq!(cookie.name_value(), ("name", "value"));
     /// ```
-    pub fn new(name: String, value: String) -> Cookie {
+    #[inline(always)]
+    pub fn new<N, V>(name: N, value: V) -> Cookie<'static>
+        where N: Into<Cow<'static, str>>,
+              V: Into<Cow<'static, str>>
+    {
         Cookie {
-            name: name,
-            value: value,
+            cookie_string: None,
+            name: CookieStr::Concrete(name.into()),
+            value: CookieStr::Concrete(value.into()),
             expires: None,
             max_age: None,
             domain: None,
             path: None,
             secure: false,
-            httponly: false,
-            custom: BTreeMap::new(),
+            http_only: false,
         }
     }
 
-    /// Attempts to parse a string into a `Cookie` instance
+    /// Parses a `Cookie` from a `String` without any allocation.
+    ///
+    /// Prefer to use this method instead of [parse](#method.parse) when the
+    /// source string is a `String` to avoid allocations while retrieving a
+    /// `Cookie` with a `static` lifetime.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let cookie = Cookie::parse_static("name=value".to_string()).unwrap();
+    /// assert_eq!(cookie.name_value(), ("name", "value"));
+    /// ```
+    pub fn parse_static<S>(string: S) -> Result<Self, ParseError>
+        where S: Into<Cow<'static, str>>
+    {
+        let storage = string.into();
+
+        // We use `unsafe` here to convince Rust to move `storage` while a
+        // borrow to it "exists". The word "exists" is placed in quotes because
+        // this piece of code ensures that a borrow _does not_ exist when the
+        // move is made. This is because the field which holds the reference,
+        // `cookie_string`, is overwritten by `storage` when it is moved into
+        // `cookie_string`. This move invalidates the borrow, and safety is
+        // preserved.
+        //
+        // This safety can be violated if the borrow passed into `parse` is
+        // stored in any other field aside from `cookie_string`. The safety
+        // invariant can thus be stated as follows: this function is safe iff
+        // the call to `Cookie::parse` stores the borrow in its first argument
+        // in at most one field of `Cookie`: `cookie_string`.
+        let parsed_cookie = unsafe {
+            let str_ptr: *const str = &*storage;
+            Cookie::parse(&*str_ptr)?
+        };
+
+        Ok(Cookie { cookie_string: Some(storage), ..parsed_cookie })
+    }
+
+    /// Creates a new `CookieBuilder` instance from the given key and value
+    /// strings.
     ///
     /// # Example
     ///
     /// ```
     /// use cookie::Cookie;
     ///
-    /// let c = Cookie::parse("foo=bar; httponly").expect("Failed to parse cookie");
-    /// assert_eq!(c.name, "foo");
-    /// assert_eq!(c.value, "bar");
-    /// assert!(c.httponly);
+    /// let c = Cookie::build("foo", "bar").finish();
+    /// assert_eq!(c.name_value(), ("foo", "bar"));
     /// ```
-    pub fn parse(s: &str) -> Result<Cookie, Error> {
-        macro_rules! unwrap_or_skip{ ($e:expr) => (
-            match $e { Some(s) => s, None => continue, }
-        ) }
+    #[inline(always)]
+    pub fn build<N, V>(name: N, value: V) -> CookieBuilder
+        where N: Into<Cow<'static, str>>,
+              V: Into<Cow<'static, str>>
+    {
+        CookieBuilder::new(name, value)
+    }
+}
 
-        let mut c = Cookie::new(String::new(), String::new());
-        let mut pairs = s.trim().split(';');
-        let keyval = match pairs.next() {
-            Some(s) => s,
-            _ => {
-                return Err(Error(()));
-            }
+impl<'c> Cookie<'c> {
+    /// Parses a `Cookie` from the given HTTP cookie header value string.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::parse("foo=bar; HttpOnly").unwrap();
+    /// assert_eq!(c.name_value(), ("foo", "bar"));
+    /// assert_eq!(c.http_only(), true);
+    /// ```
+    #[inline]
+    pub fn parse(s: &'c str) -> Result<Cookie<'c>, ParseError> {
+        parse_cookie(s)
+    }
+
+    /// Converts `self` into a `Cookie` with a static lifetime. This method
+    /// results in at most one allocation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::new("a", "b");
+    /// let owned_cookie = c.into_owned();
+    /// assert_eq!(owned_cookie.name_value(), ("a", "b"));
+    /// ```
+    #[inline]
+    pub fn into_owned(mut self) -> Cookie<'static> {
+        self.cookie_string = match self.cookie_string {
+            Some(storage) => Some(Cow::Owned(storage.into_owned())),
+            None => None,
         };
-        let (name, value) = try!(split(keyval));
-        c.name = name.into();
-        if c.name.is_empty() {
-            return Err(Error(()));
-        }
-        c.value = value.into();
 
-        for attr in pairs {
-            let (k, v) = attr_split(attr);
-            match (&k.to_ascii_lowercase()[..], v) {
-                ("secure", _) => c.secure = true,
-                ("httponly", _) => c.httponly = true,
-                ("max-age", Some(v)) => {
-                    // See RFC 6265 Section 5.2.2, negative values
-                    // indicate that the earliest possible expiration
-                    // time should be used, so set the max age as 0
-                    // seconds.
-                    let max_age: i64 = unwrap_or_skip!(v.parse().ok());
-                    c.max_age = Some(if max_age < 0 {
-                        0
-                    } else {
-                        max_age as u64
-                    });
-                },
-                ("domain", Some(v)) => {
-                    if v.is_empty() {
-                        continue;
-                    }
-
-                    let domain = if v.chars().next() == Some('.') {
-                        &v[1..]
-                    } else {
-                        v
-                    };
-                    c.domain = Some(domain.to_ascii_lowercase());
-                }
-                ("path", Some(v)) => c.path = Some(v.to_string()),
-                ("expires", Some(v)) => {
-                    // Try strptime with three date formats according to
-                    // http://tools.ietf.org/html/rfc2616#section-3.3.1
-                    // Try additional ones as encountered in the real world.
-                    let tm = time::strptime(v, "%a, %d %b %Y %H:%M:%S %Z").or_else(|_| {
-                        time::strptime(v, "%A, %d-%b-%y %H:%M:%S %Z")
-                    }).or_else(|_| {
-                        time::strptime(v, "%a, %d-%b-%Y %H:%M:%S %Z")
-                    }).or_else(|_| {
-                        time::strptime(v, "%a %b %d %H:%M:%S %Y")
-                    });
-                    let tm = unwrap_or_skip!(tm.ok());
-                    c.expires = Some(tm);
-                }
-                (_, Some(v)) => {c.custom.insert(k.to_string(), v.to_string());}
-                (_, _) => {}
-            }
-        }
-
-        return Ok(c);
-
-        fn attr_split<'a>(s: &'a str) -> (&'a str, Option<&'a str>) {
-            match s.find("=") {
-                Some(pos) => {
-                    let parts = s.split_at(pos);
-                    let value = parts.1[1..].trim();
-                    (parts.0.trim(), Some(value))
-                }
-                None => (s.trim(), None)
-            }
-        }
-
-        fn split<'a>(s: &'a str) -> Result<(&'a str, &'a str), Error> {
-            macro_rules! try {
-                ($e:expr) => (match $e {
-                    Some(s) => s,
-                    None => return Err(Error(()))
-                })
-            }
-            let mut parts = s.trim().splitn(2, '=');
-            let first = try!(parts.next()).trim();
-            let second = try!(parts.next()).trim();
-            Ok((first, second))
-        }
+        // We use `unsafe` here to convince Rust that the lifetime of `self` is
+        // in fact `static`. We know that the lifetime is indeed `static`
+        // because the only non-static field in `self`, `cookie_string`, will
+        // contain a `static` item after the assignment above.
+        //
+        // This safety can be violated if any other field aside from
+        // `cookie_string` can possible hold a non-static reference. The safety
+        // invariant can thus be stated as follows: this function is safe iff
+        // `self` has exactly one field, `cookie_string`, with a potentially
+        // non-static lifetime.
+        unsafe { ::std::mem::transmute(self) }
     }
 
-    /// Returns the (name, value) pair for this `Cookie` instance
-    pub fn pair(&self) -> AttrVal {
-        AttrVal(&self.name, &self.value)
+    /// Returns the name of `self`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::new("name", "value");
+    /// assert_eq!(c.name(), "name");
+    /// ```
+    #[inline]
+    pub fn name(&self) -> &str {
+        self.name.to_str(self.cookie_string.as_ref())
     }
-}
 
-#[cfg(feature = "serialize-serde")]
-impl Serialize for Cookie {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-        where S: serde::Serializer
-    {
-        serializer.serialize_str(&*self.to_string())
+    /// Returns the value of `self`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::new("name", "value");
+    /// assert_eq!(c.value(), "value");
+    /// ```
+    #[inline]
+    pub fn value(&self) -> &str {
+        self.value.to_str(self.cookie_string.as_ref())
     }
-}
 
-#[cfg(feature = "serialize-serde")]
-impl Deserialize for Cookie {
-    fn deserialize<D>(deserializer: &mut D) -> Result<Cookie, D::Error>
-        where D: serde::Deserializer
-    {
-        deserializer.deserialize_string(CookieVisitor)
+    /// Returns the name and value of `self` as a tuple of `(name, value)`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::new("name", "value");
+    /// assert_eq!(c.name_value(), ("name", "value"));
+    /// ```
+    #[inline(always)]
+    pub fn name_value(&self) -> (&str, &str) {
+        (self.name(), self.value())
     }
-}
-#[cfg(feature = "serialize-serde")]
-struct CookieVisitor;
 
-#[cfg(feature = "serialize-serde")]
-impl serde::de::Visitor for CookieVisitor {
-    type Value = Cookie;
-
-    fn visit_str<E>(&mut self, v: &str) -> Result<Cookie, E>
-        where E: serde::de::Error
-    {
-        match Cookie::parse(v) {
-            Ok(cookie) => Ok(cookie),
-            Err(_) => Err(serde::de::Error::custom("Could not parse serialized cookie!"))
-        }
+    /// Returns whether this cookie was marked `HttpOnly` or not.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::parse("name=value; httponly").unwrap();
+    /// assert_eq!(c.http_only(), true);
+    /// ```
+    #[inline]
+    pub fn http_only(&self) -> bool {
+        self.http_only
     }
-}
 
-/// Represents a key/value pair
-pub struct AttrVal<'a>(pub &'a str, pub &'a str);
-
-impl<'a> fmt::Display for AttrVal<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let AttrVal(ref attr, ref val) = *self;
-        write!(f, "{}={}", attr, val)
+    /// Returns whether this cookie was marked `Secure` or not.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::parse("name=value; Secure").unwrap();
+    /// assert_eq!(c.secure(), true);
+    /// ```
+    #[inline]
+    pub fn secure(&self) -> bool {
+        self.secure
     }
-}
 
-impl fmt::Display for Cookie {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(AttrVal(&self.name, &self.value).fmt(f));
-        if self.httponly { try!(write!(f, "; HttpOnly")); }
-        if self.secure { try!(write!(f, "; Secure")); }
+    /// Returns the specified max-age of the cookie if one was specified.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::parse("name=value").unwrap();
+    /// assert_eq!(c.max_age(), None);
+    ///
+    /// let c = Cookie::parse("name=value; Max-Age=3600").unwrap();
+    /// assert_eq!(c.max_age().map(|age| age.num_hours()), Some(1));
+    /// ```
+    #[inline]
+    pub fn max_age(&self) -> Option<Duration> {
+        self.max_age
+    }
+
+    /// Returns the `Path` of the cookie if one was specified.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::parse("name=value").unwrap();
+    /// assert_eq!(c.path(), None);
+    ///
+    /// let c = Cookie::parse("name=value; Path=/").unwrap();
+    /// assert_eq!(c.path(), Some("/"));
+    ///
+    /// let c = Cookie::parse("name=value; path=/sub").unwrap();
+    /// assert_eq!(c.path(), Some("/sub"));
+    /// ```
+    #[inline]
+    pub fn path(&self) -> Option<&str> {
         match self.path {
-            Some(ref s) => try!(write!(f, "; Path={}", s)),
-            None => {}
+            Some(ref c) => Some(c.to_str(self.cookie_string.as_ref())),
+            None => None,
         }
+    }
+
+    /// Returns the `Domain` of the cookie if one was specified.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::parse("name=value").unwrap();
+    /// assert_eq!(c.domain(), None);
+    ///
+    /// let c = Cookie::parse("name=value; Domain=crates.io").unwrap();
+    /// assert_eq!(c.domain(), Some("crates.io"));
+    /// ```
+    #[inline]
+    pub fn domain(&self) -> Option<&str> {
         match self.domain {
-            Some(ref s) => try!(write!(f, "; Domain={}", s)),
-            None => {}
+            Some(ref c) => Some(c.to_str(self.cookie_string.as_ref())),
+            None => None,
         }
-        match self.max_age {
-            Some(n) => try!(write!(f, "; Max-Age={}", n)),
-            None => {}
-        }
-        match self.expires {
-            Some(ref t) => try!(write!(f, "; Expires={}", t.rfc822())),
-            None => {}
+    }
+
+    /// Returns the `Expires` time of the cookie if one was specified.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let c = Cookie::parse("name=value").unwrap();
+    /// assert_eq!(c.expires(), None);
+    ///
+    /// let expire_time = "Wed, 21 Oct 2017 07:28:00 GMT";
+    /// let cookie_str = format!("name=value; Expires={}", expire_time);
+    /// let c = Cookie::parse_static(cookie_str).unwrap();
+    /// assert_eq!(c.expires().map(|t| t.tm_year), Some(117));
+    /// ```
+    #[inline]
+    pub fn expires(&self) -> Option<Tm> {
+        self.expires
+    }
+
+    /// Sets the name of `self` to `name`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let mut c = Cookie::new("name", "value");
+    /// assert_eq!(c.name(), "name");
+    ///
+    /// c.set_name("foo");
+    /// assert_eq!(c.name(), "foo");
+    /// ```
+    #[inline(always)]
+    pub fn set_name<N: Into<Cow<'static, str>>>(&mut self, name: N) {
+        self.name = CookieStr::Concrete(name.into())
+    }
+
+    /// Sets the value of `self` to `value`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let mut c = Cookie::new("name", "value");
+    /// assert_eq!(c.value(), "value");
+    ///
+    /// c.set_value("bar");
+    /// assert_eq!(c.value(), "bar");
+    /// ```
+    #[inline(always)]
+    pub fn set_value<V: Into<Cow<'static, str>>>(&mut self, value: V) {
+        self.value = CookieStr::Concrete(value.into())
+    }
+
+    /// Sets the value of `http_only` in `self` to `value`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let mut c = Cookie::new("name", "value");
+    /// assert_eq!(c.http_only(), false);
+    ///
+    /// c.set_http_only(true);
+    /// assert_eq!(c.http_only(), true);
+    /// ```
+    #[inline(always)]
+    pub fn set_http_only(&mut self, value: bool) {
+        self.http_only = value;
+    }
+
+    /// Sets the value of `secure` in `self` to `value`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let mut c = Cookie::new("name", "value");
+    /// assert_eq!(c.secure(), false);
+    ///
+    /// c.set_secure(true);
+    /// assert_eq!(c.secure(), true);
+    /// ```
+    #[inline(always)]
+    pub fn set_secure(&mut self, value: bool) {
+        self.secure = value;
+    }
+
+    /// Sets the value of `max_age` in `self` to `value`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate cookie;
+    /// extern crate time;
+    ///
+    /// use cookie::Cookie;
+    /// use time::Duration;
+    ///
+    /// # fn main() {
+    /// let mut c = Cookie::new("name", "value");
+    /// assert_eq!(c.max_age(), None);
+    ///
+    /// c.set_max_age(Duration::hours(10));
+    /// assert_eq!(c.max_age(), Some(Duration::hours(10)));
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn set_max_age(&mut self, value: Duration) {
+        self.max_age = Some(value);
+    }
+
+    /// Sets the `path` of `self` to `path`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let mut c = Cookie::new("name", "value");
+    /// assert_eq!(c.path(), None);
+    ///
+    /// c.set_path("/");
+    /// assert_eq!(c.path(), Some("/"));
+    /// ```
+    #[inline(always)]
+    pub fn set_path<P: Into<Cow<'static, str>>>(&mut self, path: P) {
+        self.path = Some(CookieStr::Concrete(path.into()));
+    }
+
+    /// Sets the `domain` of `self` to `domain`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cookie::Cookie;
+    ///
+    /// let mut c = Cookie::new("name", "value");
+    /// assert_eq!(c.domain(), None);
+    ///
+    /// c.set_domain("rust-lang.org");
+    /// assert_eq!(c.domain(), Some("rust-lang.org"));
+    /// ```
+    #[inline(always)]
+    pub fn set_domain<D: Into<Cow<'static, str>>>(&mut self, domain: D) {
+        self.domain = Some(CookieStr::Concrete(domain.into()));
+    }
+
+    /// Sets the expires field of `self` to `time`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate cookie;
+    /// extern crate time;
+    ///
+    /// use cookie::Cookie;
+    ///
+    /// # fn main() {
+    /// let mut c = Cookie::new("name", "value");
+    /// assert_eq!(c.expires(), None);
+    ///
+    /// let mut now = time::now();
+    /// now.tm_year += 1;
+    ///
+    /// c.set_expires(now);
+    /// assert!(c.expires().is_some())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn set_expires(&mut self, time: Tm) {
+        self.expires = Some(time);
+    }
+}
+
+impl<'a, 'b> PartialEq<Cookie<'b>> for Cookie<'a> {
+    fn eq(&self, other: &Cookie<'b>) -> bool {
+        let so_far_so_good = self.name() == other.name()
+            && self.value() == other.value()
+            && self.http_only() == other.http_only()
+            && self.secure() == other.secure()
+            && self.max_age() == other.max_age()
+            && self.expires() == other.expires();
+
+        if !so_far_so_good {
+            return false;
         }
 
-        for (k, v) in self.custom.iter() {
-            try!(write!(f, "; {}", AttrVal(&k, &v)));
+        match (self.path(), other.path()) {
+            (Some(a), Some(b)) if a.eq_ignore_ascii_case(b) => {}
+            (None, None) => {}
+            _ => return false,
+        };
+
+        match (self.domain(), other.domain()) {
+            (Some(a), Some(b)) if a.eq_ignore_ascii_case(b) => {}
+            (None, None) => {}
+            _ => return false,
+        };
+
+        true
+    }
+}
+
+impl<'c> fmt::Display for Cookie<'c> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Percent encode if the percent-encode feature is set.
+        #[cfg(feature = "percent-encode")]
+        let name = percent_encode(self.name().as_bytes(), USERINFO_ENCODE_SET);
+        #[cfg(feature = "percent-encode")]
+        let value = percent_encode(self.value().as_bytes(), USERINFO_ENCODE_SET);
+
+        // Don't percent encode if the feature isn't set.
+        #[cfg(not(feature = "percent-encode"))]
+        let (name, value) = self.name_value();
+
+        // Write out the compile-time determined name and value.
+        write!(f, "{}={}", name, value)?;
+
+        if self.http_only() {
+            write!(f, "; HttpOnly")?;
         }
+
+        if self.secure() {
+            write!(f, "; Secure")?;
+        }
+
+        if let Some(path) = self.path() {
+            write!(f, "; Path={}", path)?;
+        }
+
+        if let Some(domain) = self.domain() {
+            write!(f, "; Domain={}", domain)?;
+        }
+
+        if let Some(max_age) = self.max_age() {
+            write!(f, "; Max-Age={}", max_age.num_seconds())?;
+        }
+
+        if let Some(time) = self.expires() {
+            write!(f, "; Expires={}", time.rfc822())?;
+        }
+
         Ok(())
     }
 }
 
-impl FromStr for Cookie {
-    type Err = Error;
-    fn from_str(s: &str) -> Result<Cookie, Error> {
-        Cookie::parse(s)
+impl FromStr for Cookie<'static> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Cookie<'static>, ParseError> {
+        Cookie::parse(s).map(|c| c.into_owned())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Cookie;
+    use ::Cookie;
+    use ::time::{strptime, Duration};
 
     #[test]
-    fn parse() {
-        assert!(Cookie::parse("bar").is_err());
-        assert!(Cookie::parse("=bar").is_err());
-        assert!(Cookie::parse(" =bar").is_err());
-        assert!(Cookie::parse("foo=").is_ok());
-        let mut expected = Cookie::new("foo".to_string(), "bar".to_string());
-        assert_eq!(Cookie::parse("foo=bar").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse("foo = bar").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;Domain=").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;Domain= ").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;Ignored").ok().unwrap(), expected);
-        expected.httponly = true;
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;httponly").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;HTTPONLY=whatever").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ; sekure; HTTPONLY").ok().unwrap(), expected);
-        expected.secure = true;
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure=aaaa").ok().unwrap(), expected);
-        expected.max_age = Some(0);
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age=0").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age = 0 ").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age=-1").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age = -1 ").ok().unwrap(), expected);
-        expected.max_age = Some(4);
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age=4").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age = 4 ").ok().unwrap(), expected);
-        expected.path = Some("/foo".to_string());
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age=4; Path=/foo").ok().unwrap(), expected);
-        expected.domain = Some("foo.com".to_string());
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age=4; Path=/foo; \
-                                  Domain=foo.com").ok().unwrap(), expected);
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age=4; Path=/foo; \
-                                  Domain=FOO.COM").ok().unwrap(), expected);
-        expected.custom.insert("wut".to_string(), "lol".to_string());
-        assert_eq!(Cookie::parse(" foo=bar ;HttpOnly; Secure; \
-                                  Max-Age=4; Path=/foo; \
-                                  Domain=foo.com; wut=lol").ok().unwrap(), expected);
+    fn format() {
+        let cookie = Cookie::new("foo", "bar");
+        assert_eq!(&cookie.to_string(), "foo=bar");
 
-        assert_eq!(expected.to_string(),
-                   "foo=bar; HttpOnly; Secure; Path=/foo; Domain=foo.com; \
-                    Max-Age=4; wut=lol");
+        let cookie = Cookie::build("foo", "bar")
+            .http_only(true).finish();
+        assert_eq!(&cookie.to_string(), "foo=bar; HttpOnly");
+
+        let cookie = Cookie::build("foo", "bar")
+            .max_age(Duration::seconds(10)).finish();
+        assert_eq!(&cookie.to_string(), "foo=bar; Max-Age=10");
+
+        let cookie = Cookie::build("foo", "bar")
+            .secure(true).finish();
+        assert_eq!(&cookie.to_string(), "foo=bar; Secure");
+
+        let cookie = Cookie::build("foo", "bar")
+            .path("/").finish();
+        assert_eq!(&cookie.to_string(), "foo=bar; Path=/");
+
+        let cookie = Cookie::build("foo", "bar")
+            .domain("www.rust-lang.org").finish();
+        assert_eq!(&cookie.to_string(), "foo=bar; Domain=www.rust-lang.org");
+
+        let time_str = "Wed, 21 Oct 2015 07:28:00 GMT";
+        let expires = strptime(time_str, "%a, %d %b %Y %H:%M:%S %Z").unwrap();
+        let cookie = Cookie::build("foo", "bar")
+            .expires(expires).finish();
+        assert_eq!(&cookie.to_string(),
+                   "foo=bar; Expires=Wed, 21 Oct 2015 07:28:00 GMT");
     }
 
     #[test]
-    fn cookie_parse_error() {
-        match Cookie::parse("bar") {
-            Ok(_) => assert!(false),
-            Err(_) => assert!(true),
-        }
-    }
+    #[cfg(feature = "percent-encode")]
+    fn format_encoded() {
+        let cookie = Cookie::build("foo !?=", "bar;; a").finish();
+        let cookie_str = cookie.to_string();
+        assert_eq!(&cookie_str, "foo%20!%3F%3D=bar%3B%3B%20a");
 
-    #[test]
-    fn odd_characters() {
-        let expected = Cookie::new("foo".to_string(), "b%2Fr".to_string());
-        assert_eq!(Cookie::parse("foo=b%2Fr").ok().unwrap(), expected);
-    }
-
-    #[test]
-    fn pair() {
-        let cookie = Cookie::new("foo".to_string(), "bar".to_string());
-        assert_eq!(cookie.pair().to_string(), "foo=bar".to_string());
-    }
-
-    #[cfg(feature = "serialize-serde")]
-    #[test]
-    fn test_serialize() {
-        #[cfg(feature = "serialize-serde")] extern crate serde_json;
-
-        use super::Cookie;
-        use time;
-        use std::collections::BTreeMap;
-
-        let mut custom = BTreeMap::new();
-        custom.insert("x86".to_string(), "rdi".to_string());
-        custom.insert("arm".to_string(), "x0".to_string());
-        let original = Cookie {
-            name: "Hello".to_owned(),
-            value: "World!".to_owned(),
-            expires: Some(time::strptime("Sun, 23 Nov 2014 20:00:00 UTC",
-                                         "%a, %d %b %Y %H:%M:%S %Z").unwrap()),
-            max_age: Some(42),
-            domain: Some("servo.org".to_owned()),
-            path: Some("/".to_owned()),
-            secure: true,
-            httponly: false,
-            custom: custom
-        };
-
-        let serialized = serde_json::to_string(&original).unwrap();
-
-        let roundtrip: Cookie = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(original, roundtrip);
-    }
-
-    #[cfg(feature = "serialize-serde")]
-    #[test]
-    fn test_serialize_odd_characters() {
-        #[cfg(feature = "serialize-serde")] extern crate serde_json;
-
-        use super::Cookie;
-        use time;
-        use std::collections::BTreeMap;
-
-        let mut custom = BTreeMap::new();
-        custom.insert("x86".to_string(), "rdi".to_string());
-        custom.insert("arm".to_string(), "x0".to_string());
-        let original = Cookie {
-            name: "test".to_owned(),
-            value: "^start/foo=bar\\s,name@place:[test]|hello%3Bworld".to_owned(),
-            expires: Some(time::strptime("Tue, 15 Jun 2016 20:00:00 UTC",
-                                         "%a, %d %b %Y %H:%M:%S %Z").unwrap()),
-            max_age: Some(42),
-            domain: Some("example.com".to_owned()),
-            path: Some("/".to_owned()),
-            secure: true,
-            httponly: false,
-            custom: custom
-        };
-
-        let serialized = serde_json::to_string(&original).unwrap();
-
-        let roundtrip: Cookie = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(original, roundtrip);
+        let cookie = Cookie::parse_static(cookie_str).unwrap();
+        assert_eq!(cookie.name_value(), ("foo !?=", "bar;; a"));
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -22,6 +22,10 @@ pub enum ParseError {
     Utf8Error(Utf8Error),
     /// Internal error: this should not occur.
     Internal,
+    /// It is discouraged to exhaustively match on this enum as its variants may
+    /// grow without a breaking-change bump in version numbers.
+    #[doc(hidden)]
+    __Nonexhasutive,
 }
 
 impl ParseError {
@@ -35,6 +39,7 @@ impl ParseError {
             ParseError::Internal => {
                 "There was an internal error parsing the cookie. Please report this."
             }
+            ParseError::__Nonexhasutive => unreachable!("__Nonexhasutive ParseError")
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,335 @@
+use std::borrow::Cow;
+use std::error::Error;
+use std::ascii::AsciiExt;
+use std::str::Utf8Error;
+use std::fmt;
+use std::convert::From;
+
+use time::{self, Duration};
+#[cfg(feature = "percent-encode")]
+use url::percent_encoding::percent_decode;
+
+use ::{Cookie, CookieStr};
+
+/// Enum corresponding to a parsing error.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ParseError {
+    /// The cookie did not contain a name/value pair.
+    MissingPair,
+    /// The cookie's name was empty.
+    EmptyName,
+    /// Decoding the cookie's name or value resulted in invalid UTF-8.
+    Utf8Error(Utf8Error),
+    /// Internal error: this should not occur.
+    Internal,
+}
+
+impl ParseError {
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            ParseError::MissingPair => "The cookie is missing a name/value pair.",
+            ParseError::EmptyName => "The cookie's name is empty.",
+            ParseError::Utf8Error(_) => {
+                "Decoding the cookie's name or value resulted in invalid UTF-8."
+            }
+            ParseError::Internal => {
+                "There was an internal error parsing the cookie. Please report this."
+            }
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl From<Utf8Error> for ParseError {
+    fn from(error: Utf8Error) -> ParseError {
+        ParseError::Utf8Error(error)
+    }
+}
+
+impl Error for ParseError {
+    fn description(&self) -> &str {
+        self.as_str()
+    }
+}
+
+fn indexes_of(needle: &str, haystack: &str) -> Option<(usize, usize)> {
+    let haystack_start = haystack.as_ptr() as usize;
+    let needle_start = needle.as_ptr() as usize;
+
+    if needle_start < haystack_start {
+        return None;
+    }
+
+    if (needle_start + needle.len()) > (haystack_start + haystack.len()) {
+        return None;
+    }
+
+    let start = needle_start - haystack_start;
+    let end = start + needle.len();
+    Some((start, end))
+}
+
+#[cfg(not(feature = "percent-encode"))]
+fn name_val(name: &str, val: &str, s: &str) -> Result<(CookieStr, CookieStr), ParseError> {
+    let name_indexes = indexes_of(name, s).expect("name sub");
+    let value_indexes = indexes_of(val, s).expect("value sub");
+    let name = CookieStr::Indexed(name_indexes.0, name_indexes.1);
+    let val = CookieStr::Indexed(value_indexes.0, value_indexes.1);
+    Ok((name, val))
+}
+
+#[cfg(feature = "percent-encode")]
+fn name_val(name: &str, val: &str, _: &str) -> Result<(CookieStr, CookieStr), ParseError> {
+    let decoded_name = percent_decode(name.as_bytes()).decode_utf8()?;
+    let decoded_value = percent_decode(val.as_bytes()).decode_utf8()?;
+    let name = CookieStr::Concrete(Cow::Owned(decoded_name.into_owned()));
+    let val = CookieStr::Concrete(Cow::Owned(decoded_value.into_owned()));
+
+    Ok((name, val))
+}
+
+pub fn parse_cookie(s: &str) -> Result<Cookie, ParseError> {
+    let mut attributes = s.split(';');
+    let key_value = match attributes.next() {
+        Some(s) => s,
+        _ => return Err(ParseError::Internal),
+    };
+
+    // Determine the name = val.
+    let mut splits = key_value.split('=');
+    let (name, value) = match (splits.next(), splits.next()) {
+        (Some(name), Some(val)) => (name.trim(), val.trim()),
+        (Some(_), None) => return Err(ParseError::MissingPair),
+        _ => return Err(ParseError::Internal),
+    };
+
+    if name.is_empty() {
+        return Err(ParseError::EmptyName);
+    }
+
+    // Create a cookie with all of the defaults. We'll fill things in while we
+    // iterate through the parameters below.
+    let (name, value) = name_val(name, value, s)?;
+    let mut cookie = Cookie {
+        cookie_string: Some(Cow::Borrowed(s)),
+        name: name,
+        value: value,
+        expires: None,
+        max_age: None,
+        domain: None,
+        path: None,
+        secure: false,
+        http_only: false,
+    };
+
+    for attr in attributes {
+        let (key, value) = match attr.find('=') {
+            Some(i) => (attr[..i].trim(), Some(attr[(i + 1)..].trim())),
+            None => (attr.trim(), None),
+        };
+
+        match (&*key.to_ascii_lowercase(), value) {
+            ("secure", _) => cookie.secure = true,
+            ("httponly", _) => cookie.http_only = true,
+            ("max-age", Some(v)) => {
+                // See RFC 6265 Section 5.2.2, negative values indicate that the
+                // earliest possible expiration time should be used, so set the
+                // max age as 0 seconds.
+                cookie.max_age = match v.parse() {
+                    Ok(val) if val <= 0 => Some(Duration::zero()),
+                    Ok(val) => Some(Duration::seconds(val)),
+                    Err(_) => continue,
+                };
+            }
+            ("domain", Some(v)) if !v.is_empty() => {
+                let domain = match v.starts_with('.') {
+                    true => &v[1..],
+                    false => v,
+                };
+
+                let (i, j) = indexes_of(domain, s).expect("domain sub");
+                cookie.domain = Some(CookieStr::Indexed(i, j));
+            }
+            ("path", Some(v)) => {
+                let (i, j) = indexes_of(v, s).expect("path sub");
+                cookie.path = Some(CookieStr::Indexed(i, j));
+            }
+            ("expires", Some(v)) => {
+                // Try strptime with three date formats according to
+                // http://tools.ietf.org/html/rfc2616#section-3.3.1. Try
+                // additional ones as encountered in the real world.
+                let tm = time::strptime(v, "%a, %d %b %Y %H:%M:%S %Z")
+                    .or_else(|_| time::strptime(v, "%A, %d-%b-%y %H:%M:%S %Z"))
+                    .or_else(|_| time::strptime(v, "%a, %d-%b-%Y %H:%M:%S %Z"))
+                    .or_else(|_| time::strptime(v, "%a %b %d %H:%M:%S %Y"));
+
+                if let Some(time) = tm.ok() {
+                    cookie.expires = Some(time)
+                }
+            }
+            _ => {
+                // We're going to be permissive here. If we have no idea what
+                // this is, then it's something nonstandard. We're not going to
+                // store it (because it's not compliant), but we're also not
+                // going to emit an error.
+            }
+        }
+    }
+
+
+    Ok(cookie)
+}
+
+#[cfg(test)]
+mod tests {
+    use ::Cookie;
+    use ::time::{strptime, Duration};
+
+    macro_rules! assert_eq_parse {
+        ($string:expr, $expected:expr) => (
+            let cookie = match Cookie::parse($string) {
+                Ok(cookie) => cookie,
+                Err(e) => panic!("Failed to parse {:?}: {:?}", $string, e)
+            };
+
+            assert_eq!(cookie, $expected);
+        )
+    }
+
+    macro_rules! assert_ne_parse {
+        ($string:expr, $expected:expr) => (
+            let cookie = match Cookie::parse($string) {
+                Ok(cookie) => cookie,
+                Err(e) => panic!("Failed to parse {:?}: {:?}", $string, e)
+            };
+
+            assert_ne!(cookie, $expected);
+        )
+    }
+
+    #[test]
+    fn parse() {
+        assert!(Cookie::parse("bar").is_err());
+        assert!(Cookie::parse("=bar").is_err());
+        assert!(Cookie::parse(" =bar").is_err());
+        assert!(Cookie::parse("foo=").is_ok());
+
+        let mut expected = Cookie::build("foo", "bar").finish();
+        assert_eq_parse!("foo=bar", expected);
+        assert_eq_parse!("foo = bar", expected);
+        assert_eq_parse!(" foo=bar ", expected);
+        assert_eq_parse!(" foo=bar ;Domain=", expected);
+        assert_eq_parse!(" foo=bar ;Domain= ", expected);
+        assert_eq_parse!(" foo=bar ;Ignored", expected);
+
+        let mut unexpected = Cookie::build("foo", "bar").http_only(false).finish();
+        assert_ne_parse!(" foo=bar ;HttpOnly", unexpected);
+        assert_ne_parse!(" foo=bar; httponly", unexpected);
+
+        expected.set_http_only(true);
+        assert_eq_parse!(" foo=bar ;HttpOnly", expected);
+        assert_eq_parse!(" foo=bar ;httponly", expected);
+        assert_eq_parse!(" foo=bar ;HTTPONLY=whatever", expected);
+        assert_eq_parse!(" foo=bar ; sekure; HTTPONLY", expected);
+
+        expected.set_secure(true);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure", expected);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure=aaaa", expected);
+
+        unexpected.set_http_only(true);
+        unexpected.set_secure(true);
+        assert_ne_parse!(" foo=bar ;HttpOnly; skeure", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly; =secure", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly;", unexpected);
+
+        unexpected.set_secure(false);
+        assert_ne_parse!(" foo=bar ;HttpOnly; secure", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly; secure", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly; secure", unexpected);
+
+        expected.set_max_age(Duration::zero());
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=0", expected);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age = 0 ", expected);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=-1", expected);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age = -1 ", expected);
+
+        expected.set_max_age(Duration::minutes(1));
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=60", expected);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age =   60 ", expected);
+
+        expected.set_max_age(Duration::seconds(4));
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4", expected);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age = 4 ", expected);
+
+        unexpected.set_secure(true);
+        unexpected.set_max_age(Duration::minutes(1));
+        assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=122", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age = 38 ", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=51", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age = -1 ", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age = 0", unexpected);
+
+        expected.set_path("/");
+        assert_eq_parse!("foo=bar;HttpOnly; Secure; Max-Age=4; Path=/", expected);
+        assert_eq_parse!("foo=bar;HttpOnly; Secure; Max-Age=4;Path=/", expected);
+
+        expected.set_path("/foo");
+        assert_eq_parse!("foo=bar;HttpOnly; Secure; Max-Age=4; Path=/foo", expected);
+        assert_eq_parse!("foo=bar;HttpOnly; Secure; Max-Age=4;Path=/foo", expected);
+        assert_eq_parse!("foo=bar;HttpOnly; Secure; Max-Age=4;path=/foo", expected);
+        assert_eq_parse!("foo=bar;HttpOnly; Secure; Max-Age=4;path = /foo", expected);
+
+        unexpected.set_max_age(Duration::seconds(4));
+        unexpected.set_path("/bar");
+        assert_ne_parse!("foo=bar;HttpOnly; Secure; Max-Age=4; Path=/foo", unexpected);
+        assert_ne_parse!("foo=bar;HttpOnly; Secure; Max-Age=4;Path=/baz", unexpected);
+
+        expected.set_domain("www.foo.com");
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
+            Domain=www.foo.com", expected);
+
+        expected.set_domain("foo.com");
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
+            Domain=foo.com", expected);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
+            Domain=FOO.COM", expected);
+
+        unexpected.set_path("/foo");
+        unexpected.set_domain("bar.com");
+        assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
+            Domain=foo.com", unexpected);
+        assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
+            Domain=FOO.COM", unexpected);
+
+        let time_str = "Wed, 21 Oct 2015 07:28:00 GMT";
+        let expires = strptime(time_str, "%a, %d %b %Y %H:%M:%S %Z").unwrap();
+        expected.set_expires(expires);
+        assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
+            Domain=foo.com; Expires=Wed, 21 Oct 2015 07:28:00 GMT", expected);
+
+        unexpected.set_domain("foo.com");
+        let bad_expires = strptime(time_str, "%a, %d %b %Y %H:%S:%M %Z").unwrap();
+        expected.set_expires(bad_expires);
+        assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
+            Domain=foo.com; Expires=Wed, 21 Oct 2015 07:28:00 GMT", unexpected);
+    }
+
+    #[test]
+    #[cfg(not(feature = "percent-encode"))]
+    fn odd_characters() {
+        let expected = Cookie::new("foo", "b%2Fr");
+        assert_eq_parse!("foo=b%2Fr", expected);
+    }
+
+    #[test]
+    #[cfg(feature = "percent-encode")]
+    fn odd_characters() {
+        let expected = Cookie::new("foo", "b/r");
+        assert_eq_parse!("foo=b%2Fr", expected);
+    }
+}


### PR DESCRIPTION
Hello!

This pull request presents the largest change to the crate since its creation. It completely rewrites the `Cookie` structure and API. The major benefits of this rewrite are usability and performance. On the usability side, a structure following the builder pattern has been added as the primary way to construct a `Cookie`. On the performance side, parsing is now completely allocation free, and setting fields in an existing `Cookie` structure can be done in an allocation free way as well.

The summary of changes, from the main commit, is as follows:

  * `Cookie` parsing is allocation-free.
  * All fields in `Cookie` can be set allocation-free.
  * A `Cookie` can have a non-static lifetime.
  * All methods in `Cookie` are documented with examples.
  * A `Cookie` can be built via a new builder structure: `CookieBuilder`.
  * `Cookie` fields are exposed via methods instead of directly.
  * Custom, nonstandard cookie parameters are no longer supported.
  * Additional parsing tests have been added.
  * A suite of formatting tests has been added.
  * A 'percent-encode' feature has been added for automatic percent encoding.
  * Serde and Rustc serialization features have been removed.
  * The top-level crate docs have been improved.
  * The documenation URL now points to `docs.rs`.
  * The entire crate has been `rustfmt`d where possible, removing tabs.
  * The `max_age` field uses a `Duration` instead of an `i64`.

Operationally, I've bumped the version to `0.6.0` to reflect these API changes. I've also added myself as an author, which I felt was fair given that this is a rewrite of a substantial portion of the crate.

Finally, I'd like to request that I be given maintainer access to the repository. I'd really like to continue improving the crate in the future. There are many opportunities for usability and performance improvements in the `CookieJar` API, and I'd like to be able to take the responsibility of seeing them through head-on.