### PR TITLE
Overhaul `CookieJar`: more efficient, more secure, more docs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,22 +2,21 @@
 
 name = "cookie"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Sergio Benitez <sb@sergio.bz>"]
-version = "0.6.1"
+version = "0.7.0"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cookie-rs"
 documentation = "https://docs.rs/cookie"
 description = """
-Crate for parsing HTTP cookie headers and managing a cookie jar. Supports
-encrypted, signed, and permanent cookie chars composed together in a manner
-similar to Rails' cookie jar.
+Crate for parsing HTTP cookie headers and managing a cookie jar. Supports signed
+and private (encrypted + signed) jars.
 """
 
 [features]
-secure = ["openssl", "rustc-serialize"]
+secure = ["ring", "rustc-serialize"]
 percent-encode = ["url"]
 
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-openssl = { version = "0.9.0", optional = true }
+ring = { version = "0.6", optional = true }
 rustc-serialize = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ percent-encode = ["url"]
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-ring = { version = "0.6", optional = true }
+ring = { version = "0.7", optional = true }
 rustc-serialize = { version = "0.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A library for parsing HTTP cookies and managing cookie jars
 ```toml
 # Cargo.toml
 [dependencies]
-cookie = "0.6"
+cookie = "0.7"
 ```
 
 # License

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -182,6 +182,33 @@ impl CookieBuilder {
         self
     }
 
+    /// Makes the cookie being built 'permanent' by extending its expiration and
+    /// max age 20 years into the future.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate cookie;
+    /// extern crate time;
+    ///
+    /// use cookie::Cookie;
+    /// use time::Duration;
+    ///
+    /// # fn main() {
+    /// let c = Cookie::build("foo", "bar")
+    ///     .permanent()
+    ///     .finish();
+    ///
+    /// assert_eq!(c.max_age(), Some(Duration::days(365 * 20)));
+    /// # assert!(c.expires().is_some());
+    /// # }
+    /// ```
+    #[inline]
+    pub fn permanent(mut self) -> CookieBuilder {
+        self.cookie.make_permanent();
+        self
+    }
+
     /// Finishes building and returns the built `Cookie`.
     ///
     /// # Example

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,0 +1,71 @@
+use std::ops::{Deref, DerefMut};
+use std::hash::{Hash, Hasher};
+use std::borrow::Borrow;
+
+use Cookie;
+
+/// A `DeltaCookie` is a helper structure used in a cookie jar. It wraps a
+/// `Cookie` so that it can be hashed and compared purely by name. It further
+/// records whether the wrapped cookie is a "removal" cookie, that is, a cookie
+/// that when sent to the client removes the named cookie on the client's
+/// machine.
+#[derive(Clone, Debug)]
+pub struct DeltaCookie {
+    pub cookie: Cookie<'static>,
+    pub removed: bool,
+}
+
+impl DeltaCookie {
+    /// Create a new `DeltaCookie` that is being added to a jar.
+    #[inline]
+    pub fn added(cookie: Cookie<'static>) -> DeltaCookie {
+        DeltaCookie {
+            cookie: cookie,
+            removed: false,
+        }
+    }
+
+    /// Create a new `DeltaCookie` that is being removed from a jar. The
+    /// `cookie` should be a "removal" cookie.
+    #[inline]
+    pub fn removed(cookie: Cookie<'static>) -> DeltaCookie {
+        DeltaCookie {
+            cookie: cookie,
+            removed: true,
+        }
+    }
+}
+
+impl Deref for DeltaCookie {
+    type Target = Cookie<'static>;
+
+    fn deref(&self) -> &Cookie<'static> {
+        &self.cookie
+    }
+}
+
+impl DerefMut for DeltaCookie {
+    fn deref_mut(&mut self) -> &mut Cookie<'static> {
+        &mut self.cookie
+    }
+}
+
+impl PartialEq for DeltaCookie {
+    fn eq(&self, other: &DeltaCookie) -> bool {
+        self.name() == other.name()
+    }
+}
+
+impl Eq for DeltaCookie {}
+
+impl Hash for DeltaCookie {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
+    }
+}
+
+impl Borrow<str> for DeltaCookie {
+    fn borrow(&self) -> &str {
+        self.name()
+    }
+}

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -1,540 +1,365 @@
-//! A cookie jar implementation for storing a set of cookies.
-//!
-//! This CookieJar type can be used to manage a session of cookies by keeping
-//! track of cookies that are added and deleted over time. It provides a method,
-//! `delta`, which will calculate the number of `Set-Cookie` headers that need
-//! to be sent back to a client which tracks the changes in the lifetime of the
-//! jar itself.
-//!
-//! A cookie jar can also be borrowed to a child cookie jar with new
-//! functionality such as automatically signing cookies, storing permanent
-//! cookies, etc. This functionality can also be chained together.
-
-use std::collections::{HashMap, HashSet};
-use std::cell::RefCell;
-use std::fmt;
-use std::borrow::Cow;
+use std::collections::HashSet;
+use std::mem::replace;
 
 use time::{self, Duration};
 
-use ::Cookie;
+use delta::DeltaCookie;
+use Cookie;
 
-/// A jar of cookies for managing a session.
+/// A collection of cookies that tracks its modifications.
 ///
-/// # Example
+/// A `CookieJar` provides storage for any number of cookies. Any changes made
+/// to the jar are tracked; the changes can be retrieved via the
+/// [delta](#method.delta) method which returns an interator over the changes.
 ///
-/// ```
+/// # Usage
+///
+/// A jar's life begins via [new](#method.new) and calls to
+/// [add_original](#method.add_original):
+///
+/// ```rust
 /// use cookie::{Cookie, CookieJar};
 ///
-/// let c = CookieJar::new(b"f8f9eaf1ecdedff5e5b749c58115441e");
-///
-/// // Add a cookie to this jar
-/// c.add(Cookie::new("key".to_string(), "value".to_string()));
-///
-/// // Remove the added cookie
-/// c.remove("key");
+/// let mut jar = CookieJar::new();
+/// jar.add_original(Cookie::new("name", "value"));
+/// jar.add_original(Cookie::new("second", "another"));
 /// ```
-pub struct CookieJar<'a> {
-    flavor: Flavor<'a>,
+///
+/// Cookies can be added via [add](#method.add) and removed via
+/// [remove](#method.remove). Finally, cookies can be looked up via
+/// [find](#method.find):
+///
+/// ```rust
+/// # use cookie::{Cookie, CookieJar};
+/// let mut jar = CookieJar::new();
+/// jar.add(Cookie::new("a", "one"));
+/// jar.add(Cookie::new("b", "two"));
+///
+/// assert_eq!(jar.find("a").map(|c| c.value()), Some("one"));
+/// assert_eq!(jar.find("b").map(|c| c.value()), Some("two"));
+///
+/// jar.remove(Cookie::named("b"));
+/// assert!(jar.find("b").is_none());
+/// ```
+///
+/// # Deltas
+///
+/// A jar keeps track of any modifications made to it over time. The
+/// modifications are recorded as cookies. The modifications can be retrieved
+/// via [delta](#method.delta). Any new `Cookie` added to a jar via `add`
+/// results in the same `Cookie` appearing in the `delta`; cookies added via
+/// `add_original` do not count towards the delta. Any _original_ cookie that is
+/// removed from a jar results in a "removal" cookie appearing in the delta. A
+/// "removal" cookie is a cookie that a server sends so that the cookie is
+/// removed from the client's machine.
+///
+/// Deltas are typically used to create `Set-Cookie` headers corresponding to
+/// the changes made to a cookie jar over a period of time.
+///
+/// ```rust
+/// # use cookie::{Cookie, CookieJar};
+/// let mut jar = CookieJar::new();
+///
+/// // original cookies don't affect the delta
+/// jar.add_original(Cookie::new("original", "value"));
+/// assert_eq!(jar.delta().count(), 0);
+///
+/// // new cookies result in an equivalent `Cookie` in the delta
+/// jar.add(Cookie::new("a", "one"));
+/// jar.add(Cookie::new("b", "two"));
+/// assert_eq!(jar.delta().count(), 2);
+///
+/// // removing an original cookie adds a "removal" cookie to the delta
+/// jar.remove(Cookie::named("original"));
+/// assert_eq!(jar.delta().count(), 3);
+///
+/// // removing a new cookie that was added removes that `Cookie` from the delta
+/// jar.remove(Cookie::named("a"));
+/// assert_eq!(jar.delta().count(), 2);
+/// ```
+#[derive(Default, Debug, Clone)]
+pub struct CookieJar {
+    original_cookies: HashSet<DeltaCookie>,
+    delta_cookies: HashSet<DeltaCookie>,
 }
 
-enum Flavor<'a> {
-    Child(Child<'a>),
-    Root(Root),
-}
-
-struct Child<'a> {
-    parent: &'a CookieJar<'a>,
-    read: Read,
-    write: Write,
-}
-
-type Read = fn(&Root, Cookie<'static>) -> Option<Cookie<'static>>;
-type Write = fn(&Root, Cookie<'static>) -> Cookie<'static>;
-
-struct Root {
-    map: RefCell<HashMap<Cow<'static, str>, Cookie<'static>>>,
-    new_cookies: RefCell<HashSet<Cow<'static, str>>>,
-    removed_cookies: RefCell<HashSet<Cow<'static, str>>>,
-    _key: secure::SigningKey,
-}
-
-/// Iterator over the cookies in a cookie jar
-pub struct Iter<'a> {
-    jar: &'a CookieJar<'a>,
-    keys: Vec<Cow<'static, str>>,
-}
-
-impl<'a> CookieJar<'a> {
-    /// Creates a new empty cookie jar with the given signing key.
+impl CookieJar {
+    /// Creates an empty cookie jar.
     ///
-    /// The given key is used to sign cookies in the signed cookie jar. If
-    /// signed cookies aren't used then you can pass an empty array.
-    pub fn new(key: &[u8]) -> CookieJar<'static> {
-        CookieJar {
-            flavor: Flavor::Root(Root {
-                map: RefCell::new(HashMap::new()),
-                new_cookies: RefCell::new(HashSet::new()),
-                removed_cookies: RefCell::new(HashSet::new()),
-                _key: secure::prepare_key(key),
-            }),
-        }
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::CookieJar;
+    ///
+    /// let jar = CookieJar::new();
+    /// assert_eq!(jar.iter().count(), 0);
+    /// ```
+    pub fn new() -> CookieJar {
+        CookieJar::default()
     }
 
-    fn root<'b>(&'b self) -> &'b Root {
-        let mut cur = self;
-        loop {
-            match cur.flavor {
-                Flavor::Child(ref child) => cur = child.parent,
-                Flavor::Root(ref me) => return me,
-            }
-        }
+    /// Finds a `Cookie` inside this jar with the name `name` and returns a
+    /// borrow to the cookie if it is found. Otherwise returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie};
+    ///
+    /// let mut jar = CookieJar::new();
+    /// assert!(jar.find("name").is_none());
+    ///
+    /// jar.add(Cookie::new("name", "value"));
+    /// assert_eq!(jar.find("name").map(|c| c.value()), Some("value"));
+    /// ```
+    pub fn find<'a>(&'a self, name: &str) -> Option<&'a Cookie<'static>> {
+        self.delta_cookies
+            .get(name)
+            .or_else(|| self.original_cookies.get(name))
+            .and_then(|c| if !c.removed { Some(&c.cookie) } else { None })
     }
 
-    /// Adds an original cookie from a request.
+    /// Adds an "original" `cookie` to this jar. Adding an original cookie does
+    /// not affect the [delta](#method.delta) computation. This method is
+    /// intended to be used to seed the cookie jar with cookies received from a
+    /// client's HTTP message.
     ///
-    /// This method only works on the root cookie jar and is not intended for
-    /// use during the lifetime of a request, it is intended to initialize a
-    /// cookie jar from an incoming request.
+    /// For accurate `delta` computations, this method should not be called
+    /// after calling `remove`.
     ///
-    /// # Panics
+    /// # Example
     ///
-    /// Panics if `self` is not the root cookie jar.
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie};
+    ///
+    /// let mut jar = CookieJar::new();
+    /// jar.add_original(Cookie::new("name", "value"));
+    /// jar.add_original(Cookie::new("second", "two"));
+    ///
+    /// assert_eq!(jar.find("name").map(|c| c.value()), Some("value"));
+    /// assert_eq!(jar.find("second").map(|c| c.value()), Some("two"));
+    /// assert_eq!(jar.iter().count(), 2);
+    /// assert_eq!(jar.delta().count(), 0);
+    /// ```
     pub fn add_original(&mut self, cookie: Cookie<'static>) {
-        match self.flavor {
-            Flavor::Child(..) => panic!("can't add an original cookie to a child jar!"),
-            Flavor::Root(ref mut root) => {
-                let name = cookie.name().to_string();
-                root.map.borrow_mut().insert(name.into(), cookie);
-            }
-        }
+        self.original_cookies.replace(DeltaCookie::added(cookie));
     }
 
-    /// Adds a new cookie to this cookie jar.
-    ///
-    /// If this jar is a child cookie jar, this will walk up the chain of
-    /// borrowed jars, modifying the cookie as it goes along.
-    pub fn add(&self, mut cookie: Cookie<'static>) {
-        let mut cur = self;
-        let root = self.root();
-        loop {
-            match cur.flavor {
-                Flavor::Child(ref child) => {
-                    cookie = (child.write)(root, cookie);
-                    cur = child.parent;
-                }
-                Flavor::Root(..) => break,
-            }
-        }
-        let name = cookie.name().to_string();
-        root.map.borrow_mut().insert(name.clone().into(), cookie);
-        root.removed_cookies.borrow_mut().remove(&*name);
-        root.new_cookies.borrow_mut().insert(name.into());
-    }
-
-    /// Removes a cookie from this cookie jar.
-    pub fn remove<N: Into<Cow<'static, str>>>(&self, cookie_name: N) {
-        let root = self.root();
-        let name = cookie_name.into();
-        root.map.borrow_mut().remove(&name);
-        root.new_cookies.borrow_mut().remove(&name);
-        root.removed_cookies.borrow_mut().insert(name);
-    }
-
-    /// Clears all cookies from this cookie jar.
-    pub fn clear(&self) {
-        let root = self.root();
-        let all_cookies: Vec<_> = root.map
-            .borrow()
-            .keys()
-            .map(|n| n.to_owned())
-            .collect();
-
-        root.map.borrow_mut().clear();
-        root.new_cookies.borrow_mut().clear();
-        root.removed_cookies.borrow_mut().extend(all_cookies);
-    }
-
-    /// Finds a cookie inside of this cookie jar.
-    ///
-    /// The cookie is subject to modification by any of the child cookie jars
-    /// that are currently borrowed. A copy of the cookie is returned.
-    pub fn find(&self, name: &str) -> Option<Cookie<'static>> {
-        let root = self.root();
-        if root.removed_cookies.borrow().contains(name) {
-            return None;
-        }
-        root.map.borrow().get(name).and_then(|c| self.try_read(root, c.clone()))
-    }
-
-    /// Creates a child signed cookie jar.
-    ///
-    /// All cookies read from the child jar will require a valid signature and
-    /// all cookies written will be signed automatically.
-    ///
-    /// This API is only available when the `secure` feature is enabled on this
-    /// crate.
+    /// Adds `cookie` to this jar.
     ///
     /// # Example
     ///
     /// ```rust
-    /// # use cookie::{Cookie, CookieJar};
-    /// let c = CookieJar::new(b"f8f9eaf1ecdedff5e5b749c58115441e");
+    /// use cookie::{CookieJar, Cookie};
     ///
-    /// // Add a signed cookie to the jar
-    /// c.signed().add(Cookie::new("key".to_string(), "value".to_string()));
+    /// let mut jar = CookieJar::new();
+    /// jar.add(Cookie::new("name", "value"));
+    /// jar.add(Cookie::new("second", "two"));
     ///
-    /// // Add a permanently signed cookie to the jar
-    /// c.permanent().signed()
-    ///  .add(Cookie::new("key".to_string(), "value".to_string()));
+    /// assert_eq!(jar.find("name").map(|c| c.value()), Some("value"));
+    /// assert_eq!(jar.find("second").map(|c| c.value()), Some("two"));
+    /// assert_eq!(jar.iter().count(), 2);
+    /// assert_eq!(jar.delta().count(), 2);
     /// ```
-    #[cfg(feature = "secure")]
-    pub fn signed<'b>(&'b self) -> CookieJar<'b> {
-        return CookieJar {
-            flavor: Flavor::Child(Child {
-                parent: self,
-                read: verify,
-                write: sign,
-            }),
-        };
+    pub fn add(&mut self, cookie: Cookie<'static>) {
+        self.delta_cookies.replace(DeltaCookie::added(cookie));
+    }
 
-        fn verify(root: &Root, cookie: Cookie<'static>) -> Option<Cookie<'static>> {
-            secure::verify(&root._key, cookie)
+    /// Removes `cookie` from this jar. If an _original_ cookie with the same
+    /// name as `cookie` is present in the jar, a _removal_ cookie will be
+    /// present in the `delta` computation. To properly generate the removal
+    /// cookie, `cookie` must contain the same `path` and `domain` as the cookie
+    /// that was initially set.
+    ///
+    /// A "removal" cookie is a cookie that has the same name as the original
+    /// cookie but has an empty value, a max-age of 0, and an expiration date
+    /// far in the past.
+    ///
+    /// # Example
+    ///
+    /// Removing an _original_ cookie results in a _removal_ cookie:
+    ///
+    /// ```rust
+    /// # extern crate cookie;
+    /// extern crate time;
+    ///
+    /// use cookie::{CookieJar, Cookie};
+    /// use time::Duration;
+    ///
+    /// # fn main() {
+    /// let mut jar = CookieJar::new();
+    ///
+    /// // Assume this cookie originally had a path of "/" and domain of "a.b".
+    /// jar.add_original(Cookie::new("name", "value"));
+    ///
+    /// // If the path and domain were set, they must be provided to `remove`.
+    /// jar.remove(Cookie::build("name", "").path("/").domain("a.b").finish());
+    ///
+    /// // The delta will contain the removal cookie.
+    /// let delta: Vec<_> = jar.delta().collect();
+    /// assert_eq!(delta.len(), 1);
+    /// assert_eq!(delta[0].name(), "name");
+    /// assert_eq!(delta[0].max_age(), Some(Duration::seconds(0)));
+    /// # }
+    /// ```
+    ///
+    /// Removing a new cookie does not result in a _removal_ cookie:
+    ///
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie};
+    ///
+    /// let mut jar = CookieJar::new();
+    /// jar.add(Cookie::new("name", "value"));
+    /// assert_eq!(jar.delta().count(), 1);
+    ///
+    /// jar.remove(Cookie::named("name"));
+    /// assert_eq!(jar.delta().count(), 0);
+    /// ```
+    pub fn remove(&mut self, cookie: Cookie<'static>) {
+        fn make_removal_cookie(mut cookie: Cookie<'static>) -> DeltaCookie {
+            cookie.set_value("");
+            cookie.set_max_age(Duration::seconds(0));
+            cookie.set_expires(time::now() - Duration::days(365));
+            DeltaCookie::removed(cookie)
         }
 
-        fn sign(root: &Root, cookie: Cookie<'static>) -> Cookie<'static> {
-            secure::sign(&root._key, cookie)
+        if self.original_cookies.contains(cookie.name()) {
+            let delta_cookie = make_removal_cookie(cookie);
+            let original = self.original_cookies.replace(delta_cookie).unwrap();
+            self.delta_cookies.replace(make_removal_cookie(original.cookie));
+        } else {
+            self.delta_cookies.remove(cookie.name());
         }
     }
 
-    /// Creates a child encrypted cookie jar.
-    ///
-    /// All cookies read from the child jar must be encrypted and signed by a
-    /// valid key and all cookies written will be encrypted and signed
-    /// automatically.
-    ///
-    /// This API is only available when the `secure` feature is enabled on this
-    /// crate.
+    /// Removes all cookies from this cookie jar.
+    #[deprecated(since = "0.7.0", note = "calling this method may not remove \
+                 all cookies since the path and domain are not specified; use \
+                 `remove` instead")]
+    pub fn clear(&mut self) {
+        self.delta_cookies.clear();
+        for delta in replace(&mut self.original_cookies, HashSet::new()) {
+            self.remove(delta.cookie);
+        }
+    }
+
+    /// Returns an iterator over cookies that represent the changes to this jar
+    /// over time. These cookies can be rendered directly as `Set-Cookie` header
+    /// values to affect the changes made to this jar on the client.
     ///
     /// # Example
     ///
     /// ```rust
-    /// # use cookie::{Cookie, CookieJar};
-    /// let c = CookieJar::new(b"f8f9eaf1ecdedff5e5b749c58115441e");
+    /// use cookie::{CookieJar, Cookie};
     ///
-    /// // Add a signed and encrypted cookie to the jar
-    /// c.encrypted().add(Cookie::new("key".to_string(), "value".to_string()));
+    /// let mut jar = CookieJar::new();
+    /// jar.add_original(Cookie::new("name", "value"));
+    /// jar.add_original(Cookie::new("second", "two"));
     ///
-    /// // Add a permanently signed and encrypted cookie to the jar
-    /// c.permanent().encrypted()
-    ///  .add(Cookie::new("key".to_string(), "value".to_string()));
+    /// // Add new cookies.
+    /// jar.add(Cookie::new("new", "third"));
+    /// jar.add(Cookie::new("another", "fourth"));
+    /// jar.add(Cookie::new("yac", "fifth"));
+    ///
+    /// // Remove some cookies.
+    /// jar.remove(Cookie::named("name"));
+    /// jar.remove(Cookie::named("another"));
+    ///
+    /// // Delta contains two new cookies ("new", "yac") and a removal ("name").
+    /// assert_eq!(jar.delta().count(), 3);
     /// ```
-    #[cfg(feature = "secure")]
-    pub fn encrypted<'b>(&'b self) -> CookieJar<'b> {
-        return CookieJar {
-            flavor: Flavor::Child(Child {
-                parent: self,
-                read: read,
-                write: write,
-            }),
-        };
-
-        fn read(root: &Root, cookie: Cookie<'static>) -> Option<Cookie<'static>> {
-            secure::verify_and_decrypt(&root._key, cookie)
-        }
-
-        fn write(root: &Root, cookie: Cookie<'static>) -> Cookie<'static> {
-            secure::encrypt_and_sign(&root._key, cookie)
-        }
+    pub fn delta(&self) -> Delta {
+        Delta { iter: self.delta_cookies.iter() }
     }
 
-    /// Creates a child jar for permanent cookie storage.
+    /// Returns an iterator over all of the cookies present in this jar.
     ///
-    /// All cookies written to the child jar will have an expiration date 20
-    /// years into the future to ensure they stick around for a long time.
-    pub fn permanent<'b>(&'b self) -> CookieJar<'b> {
-        return CookieJar {
-            flavor: Flavor::Child(Child {
-                parent: self,
-                read: read,
-                write: write,
-            }),
-        };
-
-        fn read(_root: &Root, cookie: Cookie<'static>) -> Option<Cookie<'static>> {
-            Some(cookie)
-        }
-
-        fn write(_root: &Root, mut cookie: Cookie<'static>) -> Cookie<'static> {
-            // Expire 20 years in the future
-            cookie.set_max_age(Duration::days(365 * 20));
-            let mut now = time::now();
-            now.tm_year += 20;
-            cookie.set_expires(now);
-            cookie
-        }
-    }
-
-    /// Calculates the changes that have occurred to this cookie jar over time,
-    /// returning a vector of `Set-Cookie` headers.
-    pub fn delta(&self) -> Vec<Cookie<'static>> {
-        let mut ret = Vec::new();
-        let root = self.root();
-        for cookie in root.removed_cookies.borrow().iter() {
-            let mut c = Cookie::new(cookie.clone(), String::new());
-            c.set_max_age(Duration::zero());
-            let mut now = time::now();
-            now.tm_year -= 1;
-            c.set_expires(now);
-            ret.push(c);
-        }
-
-        let map = root.map.borrow();
-        for cookie in root.new_cookies.borrow().iter() {
-            ret.push(map.get(cookie).unwrap().clone());
-        }
-
-        return ret;
-    }
-
-    fn try_read(&self, root: &Root, mut cookie: Cookie<'static>) -> Option<Cookie<'static>> {
-        let mut jar = self;
-        loop {
-            match jar.flavor {
-                Flavor::Child(Child { read, parent, .. }) => {
-                    cookie = match read(root, cookie) {
-                        Some(c) => c,
-                        None => return None,
-                    };
-                    jar = parent;
-                }
-                Flavor::Root(..) => return Some(cookie),
-            }
-        }
-    }
-
-    /// Return an iterator over the cookies in this jar.
+    /// # Example
     ///
-    /// This iterator will only yield valid cookies for this jar. For example if
-    /// this is an encrypted child jar then only valid encrypted cookies will be
-    /// yielded. If the root cookie jar is iterated over then all cookies will
-    /// be yielded.
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie};
+    ///
+    /// let mut jar = CookieJar::new();
+    ///
+    /// jar.add_original(Cookie::new("name", "value"));
+    /// jar.add_original(Cookie::new("second", "two"));
+    ///
+    /// jar.add(Cookie::new("new", "third"));
+    /// jar.add(Cookie::new("another", "fourth"));
+    /// jar.add(Cookie::new("yac", "fifth"));
+    ///
+    /// jar.remove(Cookie::named("name"));
+    /// jar.remove(Cookie::named("another"));
+    ///
+    /// // There are three cookies in the jar: "second", "new", and "yac".
+    /// # assert_eq!(jar.iter().count(), 3);
+    /// for cookie in jar.iter() {
+    ///     match cookie.name() {
+    ///         "second" => assert_eq!(cookie.value(), "two"),
+    ///         "new" => assert_eq!(cookie.value(), "third"),
+    ///         "yac" => assert_eq!(cookie.value(), "fifth"),
+    ///         _ => unreachable!("there are only three cookies in the jar")
+    ///     }
+    /// }
+    /// ```
     pub fn iter(&self) -> Iter {
-        let map = self.root().map.borrow();
-        Iter {
-            jar: self,
-            keys: map.keys().cloned().collect(),
-        }
+        Iter { delta_cookies: self.delta_cookies.union(&self.original_cookies) }
     }
 }
 
-impl<'a> fmt::Debug for CookieJar<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let root = self.root();
-        try!(write!(f, "CookieJar {{"));
-        let mut first = true;
-        for (name, cookie) in &*root.map.borrow() {
-            if !first {
-                try!(write!(f, ", "));
-            }
-            first = false;
-            try!(write!(f, "{:?}: {:?}", name, cookie));
-        }
-        try!(write!(f, " }}"));
-        Ok(())
+use std::collections::hash_set::Iter as HashSetIter;
+
+/// Iterator over the changes to a cookie jar.
+pub struct Delta<'a> {
+    iter: HashSetIter<'a, DeltaCookie>,
+}
+
+impl<'a> Iterator for Delta<'a> {
+    type Item = &'a Cookie<'static>;
+
+    fn next(&mut self) -> Option<&'a Cookie<'static>> {
+        self.iter.next().map(|c| &c.cookie)
     }
+}
+
+use std::collections::hash_set::Union;
+use std::collections::hash_map::RandomState;
+
+/// Iterator over all of the cookies in a jar.
+pub struct Iter<'a> {
+    delta_cookies: Union<'a, DeltaCookie, RandomState>,
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = Cookie<'static>;
+    type Item = &'a Cookie<'static>;
 
-    fn next(&mut self) -> Option<Cookie<'static>> {
-        loop {
-            let key = match self.keys.pop() {
-                Some(v) => v,
-                None => return None,
-            };
-            let root = self.jar.root();
-            let map = root.map.borrow();
-            let cookie = match map.get(&key) {
-                Some(cookie) => cookie.clone(),
-                None => continue,
-            };
-            match self.jar.try_read(root, cookie) {
-                Some(cookie) => return Some(cookie),
-                None => {}
+    fn next(&mut self) -> Option<&'a Cookie<'static>> {
+        while let Some(cookie) = self.delta_cookies.next() {
+            if !cookie.removed {
+                return Some(&*cookie);
             }
         }
+
+        None
     }
-}
-
-
-#[cfg(not(feature = "secure"))]
-mod secure {
-    pub type SigningKey = ();
-
-    pub fn prepare_key(_key: &[u8]) -> () {
-        ()
-    }
-}
-
-#[cfg(feature = "secure")]
-mod secure {
-    extern crate openssl;
-    extern crate rustc_serialize;
-
-    use ::Cookie;
-    use self::openssl::{hash, memcmp, symm};
-    use self::openssl::pkey::PKey;
-    use self::openssl::sign::Signer;
-    use self::openssl::hash::MessageDigest;
-    use self::rustc_serialize::base64::{ToBase64, FromBase64, STANDARD};
-
-    pub type SigningKey = Vec<u8>;
-    pub const MIN_KEY_LEN: usize = 32;
-
-    pub fn prepare_key(key: &[u8]) -> Vec<u8> {
-        if key.len() >= MIN_KEY_LEN {
-            key.to_vec()
-        } else {
-            // Using a SHA-256 hash to normalize key as Rails suggests.
-            hash::hash(MessageDigest::sha256(), key).unwrap()
-        }
-    }
-
-    // If a SHA1 HMAC is good enough for rails, it's probably good enough
-    // for us as well:
-    //
-    // https://github.com/rails/rails/blob/master/activesupport/lib
-    //                   /active_support/message_verifier.rb#L70
-    pub fn sign(key: &[u8], mut cookie: Cookie<'static>) -> Cookie<'static> {
-        let signature = dosign(key, cookie.value()).to_base64(STANDARD);
-        let new_cookie_val = format!("{}--{}", cookie.value(), signature);
-        cookie.set_value(new_cookie_val);
-        cookie
-    }
-
-    fn split_value(val: &str) -> Option<(&str, Vec<u8>)> {
-        let parts = val.split("--");
-        let ext = match parts.last() {
-            Some(ext) => ext,
-            _ => return None,
-        };
-        let val_len = val.len();
-        if ext.len() == val_len {
-            return None;
-        }
-        let text = &val[..val_len - ext.len() - 2];
-        let ext = match ext.from_base64() {
-            Ok(sig) => sig,
-            Err(..) => return None,
-        };
-
-        Some((text, ext))
-    }
-
-    pub fn verify(key: &[u8], mut cookie: Cookie<'static>) -> Option<Cookie<'static>> {
-        let (text, signature) = match split_value(cookie.value()) {
-            Some((text, sig)) => (text.to_string(), sig),
-            None => return None,
-        };
-
-
-        let expected = dosign(key, &text);
-        if expected.len() != signature.len() || !memcmp::eq(&expected, &signature) {
-            return None;
-        }
-
-        cookie.set_value(text);
-        Some(cookie)
-    }
-
-    fn dosign(key: &[u8], val: &str) -> Vec<u8> {
-        let pkey = PKey::hmac(key).unwrap();
-        let mut signer = Signer::new(MessageDigest::sha1(), &pkey).unwrap();
-        signer.update(val.as_bytes()).unwrap();
-        signer.finish().unwrap()
-    }
-
-    // Implementation details were taken from Rails. See
-    // https://github.com/rails/rails/blob/master/activesupport/lib/active_support/message_encryptor.rb#L57
-    pub fn encrypt_and_sign(key: &[u8], mut cookie: Cookie<'static>) -> Cookie<'static> {
-        let encrypted_data = encrypt_data(key, cookie.value());
-        cookie.set_value(encrypted_data);
-        sign(key, cookie)
-    }
-
-    fn encrypt_data(key: &[u8], val: &str) -> String {
-        let iv = random_iv();
-        let iv_str = iv.to_base64(STANDARD);
-
-        let cipher = symm::Cipher::aes_256_cbc();
-        let encrypted = symm::encrypt(cipher, &key[..MIN_KEY_LEN], Some(&iv), val.as_bytes());
-        let mut encrypted_data = encrypted.unwrap().to_base64(STANDARD);
-
-        encrypted_data.push_str("--");
-        encrypted_data.push_str(&iv_str);
-        encrypted_data
-    }
-
-    pub fn verify_and_decrypt(key: &[u8], cookie: Cookie<'static>) -> Option<Cookie<'static>> {
-        let mut cookie = match verify(key, cookie) {
-            Some(cookie) => cookie,
-            None => return None,
-        };
-
-        decrypt_data(key, cookie.value())
-            .and_then(|data| String::from_utf8(data).ok())
-            .map(move |val| {
-                cookie.set_value(val);
-                cookie
-            })
-    }
-
-    fn decrypt_data(key: &[u8], val: &str) -> Option<Vec<u8>> {
-        let (val, iv) = match split_value(val) {
-            Some(pair) => pair,
-            None => return None,
-        };
-
-        let actual = match val.from_base64() {
-            Ok(actual) => actual,
-            Err(_) => return None,
-        };
-
-        Some(symm::decrypt(symm::Cipher::aes_256_cbc(),
-                           &key[..MIN_KEY_LEN],
-                           Some(&iv),
-                           &actual)
-            .unwrap())
-    }
-
-    fn random_iv() -> Vec<u8> {
-        let mut ret = vec![0; 16];
-        openssl::rand::rand_bytes(&mut ret).unwrap();
-        return ret;
-    }
-
 }
 
 #[cfg(test)]
 mod test {
-    use {Cookie, CookieJar};
+    use super::CookieJar;
+    use Cookie;
 
-    const KEY: &'static [u8] = b"f8f9eaf1ecdedff5e5b749c58115441e";
-
-    #[test]
-    fn short_key() {
-        CookieJar::new(b"foo");
-    }
+    #[cfg(feature = "secure")]
+    use secure::{Signed, Private};
 
     #[test]
+    #[allow(deprecated)]
     fn simple() {
-        let c = CookieJar::new(KEY);
+        let mut c = CookieJar::new();
 
         c.add(Cookie::new("test", ""));
         c.add(Cookie::new("test2", ""));
-        c.remove("test");
+        c.remove(Cookie::named("test"));
 
         assert!(c.find("test").is_none());
         assert!(c.find("test2").is_some());
@@ -547,91 +372,150 @@ mod test {
         assert!(c.find("test3").is_none());
     }
 
-    macro_rules! secure_behaviour {
-        ($c:ident, $secure:ident) => ({
-            $c.$secure().add(Cookie::new("test", "test"));
-            assert!($c.find("test").unwrap().value() != "test");
-            assert!($c.$secure().find("test").unwrap().value() == "test");
+    #[test]
+    fn jar_is_send() {
+        fn is_send<T: Send>(_: T) -> bool {
+            true
+        }
 
-            let mut cookie = $c.find("test").unwrap();
-            let new_val = format!("{}l", cookie.value());
-            cookie.set_value(new_val);
-            $c.add(cookie);
-            assert!($c.$secure().find("test").is_none());
-
-            let mut cookie = $c.find("test").unwrap();
-            cookie.set_value("foobar");
-            $c.add(cookie);
-            assert!($c.$secure().find("test").is_none());
-        })
+        assert!(is_send(CookieJar::new()))
     }
 
+    #[test]
     #[cfg(feature = "secure")]
-    #[test]
-    fn signed() {
-        let c = CookieJar::new(KEY);
-        secure_behaviour!(c, signed)
-    }
-
-    #[cfg(feature = "secure")]
-    #[test]
-    fn encrypted() {
-        let c = CookieJar::new(KEY);
-        secure_behaviour!(c, encrypted)
-    }
-
-    #[test]
-    fn permanent() {
-        let c = CookieJar::new(KEY);
-
-        c.permanent().add(Cookie::new("test", "test"));
-
-        let cookie = c.find("test").unwrap();
-        assert_eq!(cookie.value(), "test");
-        assert_eq!(c.permanent().find("test").unwrap().value(), "test");
-        assert!(cookie.expires().is_some());
-        assert!(cookie.max_age().is_some());
-    }
-
-    #[cfg(feature = "secure")]
-    #[test]
-    fn chained() {
-        let c = CookieJar::new(KEY);
-        c.permanent().signed().add(Cookie::new("test", "test"));
-
-        let cookie = c.signed().find("test").unwrap();
-        assert_eq!(cookie.value(), "test");
-        assert!(cookie.expires().is_some());
-        assert!(cookie.max_age().is_some());
-    }
-
-    #[cfg(features = "secure")]
-    #[test]
     fn iter() {
-        let mut c = CookieJar::new(KEY);
+        let key: Vec<u8> = (0..64).collect();
+        let mut c = CookieJar::new();
 
         c.add_original(Cookie::new("original", "original"));
 
         c.add(Cookie::new("test", "test"));
         c.add(Cookie::new("test2", "test2"));
         c.add(Cookie::new("test3", "test3"));
+        assert_eq!(c.iter().count(), 4);
+
+        c.signed(&key).add(Cookie::new("signed", "signed"));
+        c.private(&key[..32]).add(Cookie::new("encrypted", "encrypted"));
+        assert_eq!(c.iter().count(), 6);
+
+        c.remove(Cookie::named("test"));
+        assert_eq!(c.iter().count(), 5);
+
+        c.remove(Cookie::named("signed"));
+        c.remove(Cookie::named("test2"));
+        assert_eq!(c.iter().count(), 3);
+
+        c.add(Cookie::new("test2", "test2"));
+        assert_eq!(c.iter().count(), 4);
+
+        c.remove(Cookie::named("test2"));
+        assert_eq!(c.iter().count(), 3);
+    }
+
+    #[test]
+    #[cfg(feature = "secure")]
+    fn delta() {
+        use std::collections::HashMap;
+        use time::Duration;
+
+        let mut c = CookieJar::new();
+
+        c.add_original(Cookie::new("original", "original"));
+        c.add_original(Cookie::new("original1", "original1"));
+
+        c.add(Cookie::new("test", "test"));
+        c.add(Cookie::new("test2", "test2"));
+        c.add(Cookie::new("test3", "test3"));
         c.add(Cookie::new("test4", "test4"));
 
-        c.signed().add(Cookie::new("signed", "signed"));
+        c.remove(Cookie::named("test"));
+        c.remove(Cookie::named("original"));
 
-        c.encrypted().add(Cookie::new("encrypted", "encrypted"));
+        assert_eq!(c.delta().count(), 4);
 
-        c.remove("test");
+        let names: HashMap<_, _> = c.delta()
+            .map(|c| (c.name(), c.max_age()))
+            .collect();
 
-        let cookies = c.iter().collect::<Vec<_>>();
-        assert_eq!(cookies.len(), 6);
+        assert!(names.get("test2").unwrap().is_none());
+        assert!(names.get("test3").unwrap().is_none());
+        assert!(names.get("test4").unwrap().is_none());
+        assert_eq!(names.get("original").unwrap(), &Some(Duration::seconds(0)));
 
-        let encrypted_cookies = c.encrypted().iter().collect::<Vec<_>>();
-        assert_eq!(encrypted_cookies.len(), 1);
-        assert_eq!(encrypted_cookies[0].name, "encrypted");
+    }
 
-        let signed_cookies = c.signed().iter().collect::<Vec<_>>();
-        assert_eq!(signed_cookies.len(), 2);
-        assert!(signed_cookies[0].name == "signed" || signed_cookies[1].name == "signed");
+    #[test]
+    fn replace_original() {
+        let mut jar = CookieJar::new();
+        jar.add_original(Cookie::new("original_a", "a"));
+        jar.add_original(Cookie::new("original_b", "b"));
+        assert_eq!(jar.find("original_a").unwrap().value(), "a");
+
+        jar.add(Cookie::new("original_a", "av2"));
+        assert_eq!(jar.find("original_a").unwrap().value(), "av2");
+    }
+
+    #[test]
+    fn empty_delta() {
+        let mut jar = CookieJar::new();
+        jar.add(Cookie::new("name", "val"));
+        assert_eq!(jar.delta().count(), 1);
+
+        jar.remove(Cookie::named("name"));
+        assert_eq!(jar.delta().count(), 0);
+
+        jar.add_original(Cookie::new("name", "val"));
+        assert_eq!(jar.delta().count(), 0);
+
+        jar.remove(Cookie::named("name"));
+        assert_eq!(jar.delta().count(), 1);
+
+        jar.add(Cookie::new("name", "val"));
+        assert_eq!(jar.delta().count(), 1);
+
+        jar.remove(Cookie::named("name"));
+        assert_eq!(jar.delta().count(), 1);
+    }
+
+    #[test]
+    fn add_remove_add() {
+        let mut jar = CookieJar::new();
+        jar.add_original(Cookie::new("name", "val"));
+        assert_eq!(jar.delta().count(), 0);
+
+        jar.remove(Cookie::named("name"));
+        assert_eq!(jar.delta().filter(|c| c.value().is_empty()).count(), 1);
+        assert_eq!(jar.delta().count(), 1);
+
+        // The cookie's been deleted. Another original doesn't change that.
+        jar.add_original(Cookie::new("name", "val"));
+        assert_eq!(jar.delta().filter(|c| c.value().is_empty()).count(), 1);
+        assert_eq!(jar.delta().count(), 1);
+
+        jar.remove(Cookie::named("name"));
+        assert_eq!(jar.delta().filter(|c| c.value().is_empty()).count(), 1);
+        assert_eq!(jar.delta().count(), 1);
+
+        jar.add(Cookie::new("name", "val"));
+        assert_eq!(jar.delta().filter(|c| !c.value().is_empty()).count(), 1);
+        assert_eq!(jar.delta().count(), 1);
+
+        jar.remove(Cookie::named("name"));
+        assert_eq!(jar.delta().filter(|c| c.value().is_empty()).count(), 1);
+        assert_eq!(jar.delta().count(), 1);
+    }
+
+    #[test]
+    fn replace_remove() {
+        let mut jar = CookieJar::new();
+        jar.add_original(Cookie::new("name", "val"));
+        assert_eq!(jar.delta().count(), 0);
+
+        jar.add(Cookie::new("name", "val"));
+        assert_eq!(jar.delta().count(), 1);
+        assert_eq!(jar.delta().filter(|c| !c.value().is_empty()).count(), 1);
+
+        jar.remove(Cookie::named("name"));
+        assert_eq!(jar.delta().filter(|c| c.value().is_empty()).count(), 1);
     }
 }

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -311,7 +311,8 @@ impl CookieJar {
     /// Returns a `PrivateJar` with `self` as its parent jar using the key `key`
     /// to sign/encrypt and verify/decrypt cookies added/retrieved from the
     /// child jar. The key must be exactly 32 bytes. For security, the key
-    /// _must_ be cryptographically random.
+    /// _must_ be cryptographically random and _different_ from a key used for
+    /// a signed jar, if any.
     ///
     /// Any modifications to the child jar will be reflected on the parent jar,
     /// and any retrievals from the child jar will be made from the parent jar.
@@ -353,8 +354,8 @@ impl CookieJar {
 
     /// Returns a `SignedJar` with `self` as its parent jar using the key `key`
     /// to sign/verify cookies added/retrieved from the child jar. The key must
-    /// be exactly 64 bytes. For security, the key _must_ be cryptographically
-    /// random.
+    /// be exactly 32 bytes. For security, the key _must_ be cryptographically
+    /// random and _different_ from a key used for a private jar, if any.
     ///
     /// Any modifications to the child jar will be reflected on the parent jar,
     /// and any retrievals from the child jar will be made from the parent jar.
@@ -363,7 +364,7 @@ impl CookieJar {
     ///
     /// # Panics
     ///
-    /// Panics if `key` is not exactly 64 bytes long.
+    /// Panics if `key` is not exactly 32 bytes long.
     ///
     /// # Example
     ///
@@ -371,7 +372,7 @@ impl CookieJar {
     /// use cookie::{Cookie, CookieJar};
     ///
     /// // We use a bogus key for demonstration purposes.
-    /// let key: Vec<_> = (0..64).collect();
+    /// let key: Vec<_> = (0..32).collect();
     ///
     /// // Add a signed cookie.
     /// let mut jar = CookieJar::new();
@@ -480,8 +481,8 @@ mod test {
         c.add(Cookie::new("test3", "test3"));
         assert_eq!(c.iter().count(), 4);
 
-        c.signed(&key).add(Cookie::new("signed", "signed"));
-        c.private(&key[..32]).add(Cookie::new("encrypted", "encrypted"));
+        c.signed(&key[..32]).add(Cookie::new("signed", "signed"));
+        c.private(&key[32..]).add(Cookie::new("encrypted", "encrypted"));
         assert_eq!(c.iter().count(), 6);
 
         c.remove(Cookie::named("test"));

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -347,7 +347,7 @@ impl CookieJar {
     /// assert!(jar.get("private").is_some());
     /// ```
     #[cfg(feature = "secure")]
-    pub fn private<'a, 'k>(&'a mut self, key: &'k [u8]) -> PrivateJar<'a, 'k> {
+    pub fn private<'a, 'k>(&'a mut self, key: &[u8]) -> PrivateJar<'a> {
         PrivateJar::new(self, key)
     }
 
@@ -391,7 +391,7 @@ impl CookieJar {
     /// assert!(jar.get("signed").is_some());
     /// ```
     #[cfg(feature = "secure")]
-    pub fn signed<'a, 'k>(&'a mut self, key: &'k [u8]) -> SignedJar<'a, 'k> {
+    pub fn signed<'a>(&'a mut self, key: &[u8]) -> SignedJar<'a> {
         SignedJar::new(self, key)
     }
 }

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -27,7 +27,7 @@ use Cookie;
 ///
 /// Cookies can be added via [add](#method.add) and removed via
 /// [remove](#method.remove). Finally, cookies can be looked up via
-/// [find](#method.find):
+/// [get](#method.get):
 ///
 /// ```rust
 /// # use cookie::{Cookie, CookieJar};
@@ -35,11 +35,11 @@ use Cookie;
 /// jar.add(Cookie::new("a", "one"));
 /// jar.add(Cookie::new("b", "two"));
 ///
-/// assert_eq!(jar.find("a").map(|c| c.value()), Some("one"));
-/// assert_eq!(jar.find("b").map(|c| c.value()), Some("two"));
+/// assert_eq!(jar.get("a").map(|c| c.value()), Some("one"));
+/// assert_eq!(jar.get("b").map(|c| c.value()), Some("two"));
 ///
 /// jar.remove(Cookie::named("b"));
-/// assert!(jar.find("b").is_none());
+/// assert!(jar.get("b").is_none());
 /// ```
 ///
 /// # Deltas
@@ -98,8 +98,8 @@ impl CookieJar {
         CookieJar::default()
     }
 
-    /// Finds a `Cookie` inside this jar with the name `name` and returns a
-    /// borrow to the cookie if it is found. Otherwise returns `None`.
+    /// Returns a reference to the `Cookie` inside this jar with the name
+    /// `name`. If no such cookie exists, returns `None`.
     ///
     /// # Example
     ///
@@ -107,12 +107,12 @@ impl CookieJar {
     /// use cookie::{CookieJar, Cookie};
     ///
     /// let mut jar = CookieJar::new();
-    /// assert!(jar.find("name").is_none());
+    /// assert!(jar.get("name").is_none());
     ///
     /// jar.add(Cookie::new("name", "value"));
-    /// assert_eq!(jar.find("name").map(|c| c.value()), Some("value"));
+    /// assert_eq!(jar.get("name").map(|c| c.value()), Some("value"));
     /// ```
-    pub fn find<'a>(&'a self, name: &str) -> Option<&'a Cookie<'static>> {
+    pub fn get(&self, name: &str) -> Option<&Cookie<'static>> {
         self.delta_cookies
             .get(name)
             .or_else(|| self.original_cookies.get(name))
@@ -136,8 +136,8 @@ impl CookieJar {
     /// jar.add_original(Cookie::new("name", "value"));
     /// jar.add_original(Cookie::new("second", "two"));
     ///
-    /// assert_eq!(jar.find("name").map(|c| c.value()), Some("value"));
-    /// assert_eq!(jar.find("second").map(|c| c.value()), Some("two"));
+    /// assert_eq!(jar.get("name").map(|c| c.value()), Some("value"));
+    /// assert_eq!(jar.get("second").map(|c| c.value()), Some("two"));
     /// assert_eq!(jar.iter().count(), 2);
     /// assert_eq!(jar.delta().count(), 0);
     /// ```
@@ -156,8 +156,8 @@ impl CookieJar {
     /// jar.add(Cookie::new("name", "value"));
     /// jar.add(Cookie::new("second", "two"));
     ///
-    /// assert_eq!(jar.find("name").map(|c| c.value()), Some("value"));
-    /// assert_eq!(jar.find("second").map(|c| c.value()), Some("two"));
+    /// assert_eq!(jar.get("name").map(|c| c.value()), Some("value"));
+    /// assert_eq!(jar.get("second").map(|c| c.value()), Some("two"));
     /// assert_eq!(jar.iter().count(), 2);
     /// assert_eq!(jar.delta().count(), 2);
     /// ```
@@ -361,15 +361,15 @@ mod test {
         c.add(Cookie::new("test2", ""));
         c.remove(Cookie::named("test"));
 
-        assert!(c.find("test").is_none());
-        assert!(c.find("test2").is_some());
+        assert!(c.get("test").is_none());
+        assert!(c.get("test2").is_some());
 
         c.add(Cookie::new("test3", ""));
         c.clear();
 
-        assert!(c.find("test").is_none());
-        assert!(c.find("test2").is_none());
-        assert!(c.find("test3").is_none());
+        assert!(c.get("test").is_none());
+        assert!(c.get("test2").is_none());
+        assert!(c.get("test3").is_none());
     }
 
     #[test]
@@ -449,10 +449,10 @@ mod test {
         let mut jar = CookieJar::new();
         jar.add_original(Cookie::new("original_a", "a"));
         jar.add_original(Cookie::new("original_b", "b"));
-        assert_eq!(jar.find("original_a").unwrap().value(), "a");
+        assert_eq!(jar.get("original_a").unwrap().value(), "a");
 
         jar.add(Cookie::new("original_a", "av2"));
-        assert_eq!(jar.find("original_a").unwrap().value(), "av2");
+        assert_eq!(jar.get("original_a").unwrap().value(), "av2");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,9 @@
 //!
 //!   Enables signed and private (signed + encrypted) cookie jars.
 //!
-//!   When this feature is enabled, the [Signed](trait.Signed.html) and
-//!   [Private](trait.Private.html) traits and
+//!   When this feature is enabled, the
+//!   [signed](struct.CookieJar.html#method.signed) and
+//!   [private](struct.CookieJar.html#method.private) method of `CookieJar` and
 //!   [SignedJar](struct.SignedJar.html) and
 //!   [PrivateJar](struct.PrivateJar.html) structures are available. The jars
 //!   act as "children jars", allowing for easy retrieval and addition of signed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! HTTP Cookie parsing and Cookie Jar management.
+//! HTTP cookie parsing and cookie jar management.
 //!
 //! This crates provides the [Cookie](struct.Cookie.html) type, which directly
 //! maps to an HTTP cookie, and the [CookieJar](struct.CookieJar.html) type,
@@ -10,7 +10,7 @@
 //! Add the following to the `[dependencies]` section of your `Cargo.toml`:
 //!
 //! ```ignore
-//! cookie = "0.6"
+//! cookie = "0.7"
 //! ```
 //!
 //! Then add the following line to your crate root:
@@ -25,13 +25,17 @@
 //! features:
 //!
 //!
-//! * **secure** (enabled by default)
+//! * **secure** (disabled by default)
 //!
-//!   Enables signing and encryption of cookies.
+//!   Enables signed and private (signed + encrypted) cookie jars.
 //!
-//!   When this feature is enabled, signed and encrypted cookies jars will
-//!   encrypt and/or sign any cookies added to them. When this feature is
-//!   disabled, those cookies will be added in plaintext.
+//!   When this feature is enabled, the [Signed](trait.Signed.html) and
+//!   [Private](trait.Private.html) traits and
+//!   [SignedJar](struct.SignedJar.html) and
+//!   [PrivateJar](struct.PrivateJar.html) structures are available. The jars
+//!   act as "children jars", allowing for easy retrieval and addition of signed
+//!   and/or encrypted cookies to a cookie jar. When this feature is disabled,
+//!   none of the types are available.
 //!
 //! * **percent-encode** (disabled by default)
 //!
@@ -53,17 +57,19 @@
 //! features = ["secure", "percent-encode"]
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/cookie/0.6")]
+#![doc(html_root_url = "https://docs.rs/cookie/0.7")]
 #![deny(missing_docs)]
-#![cfg_attr(test, deny(warnings))]
 
-#[cfg(feature = "percent-encode")]
-extern crate url;
+#[cfg(feature = "percent-encode")] extern crate url;
 extern crate time;
 
 mod builder;
-mod jar;
 mod parse;
+mod jar;
+mod delta;
+
+#[cfg(feature = "secure")] #[macro_use] mod secure;
+#[cfg(feature = "secure")] pub use secure::*;
 
 use std::borrow::Cow;
 use std::ascii::AsciiExt;
@@ -78,7 +84,7 @@ use parse::parse_cookie;
 pub use parse::ParseError;
 
 pub use builder::CookieBuilder;
-pub use jar::CookieJar;
+pub use jar::{CookieJar, Delta, Iter};
 
 #[derive(Debug, Clone)]
 enum CookieStr {
@@ -192,6 +198,23 @@ impl Cookie<'static> {
             secure: false,
             http_only: false,
         }
+    }
+
+    /// Creates a new `Cookie` with the given name and an empty value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let cookie = Cookie::named("name");
+    /// assert_eq!(cookie.name(), "name");
+    /// assert!(cookie.value().is_empty());
+    /// ```
+    pub fn named<N>(name: N) -> Cookie<'static>
+        where N: Into<Cow<'static, str>>
+    {
+        Cookie::new(name, "")
     }
 
     /// Creates a new `CookieBuilder` instance from the given key and value
@@ -613,6 +636,34 @@ impl<'c> Cookie<'c> {
         self.expires = Some(time);
     }
 
+    /// Makes `self` a "permanent" cookie by extending its expiration and max
+    /// age 20 years into the future.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate cookie;
+    /// extern crate time;
+    ///
+    /// use cookie::Cookie;
+    /// use time::Duration;
+    ///
+    /// # fn main() {
+    /// let mut c = Cookie::new("foo", "bar");
+    /// assert!(c.expires().is_none());
+    /// assert!(c.max_age().is_none());
+    ///
+    /// c.make_permanent();
+    /// assert!(c.expires().is_some());
+    /// assert_eq!(c.max_age(), Some(Duration::days(365 * 20)));
+    /// # }
+    /// ```
+    pub fn make_permanent(&mut self) {
+        let twenty_years = Duration::days(365 * 20);
+        self.set_max_age(twenty_years);
+        self.set_expires(time::now() + twenty_years);
+    }
+
     fn fmt_parameters(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.http_only() {
             write!(f, "; HttpOnly")?;
@@ -677,6 +728,19 @@ impl<'a, 'c: 'a> fmt::Display for EncodedCookie<'a, 'c> {
 }
 
 impl<'c> fmt::Display for Cookie<'c> {
+    /// Formats the cookie `self` as a `Set-Cookie` header value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Cookie;
+    ///
+    /// let mut cookie = Cookie::build("foo", "bar")
+    ///     .path("/")
+    ///     .finish();
+    ///
+    /// assert_eq!(&cookie.to_string(), "foo=bar; Path=/");
+    /// ```
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}={}", self.name(), self.value())?;
         self.fmt_parameters(f)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -102,13 +102,10 @@ fn parse_inner<'c>(s: &str, decode: bool) -> Result<Cookie<'c>, ParseError> {
     };
 
     // Determine the name = val.
-    let (name, value) =
-        if let Some(i) = key_value.find('=') {
-            let (n, v) = key_value.split_at(i);
-            (n.trim(), (&v[1..]).trim())
-        } else {
-            return Err(ParseError::MissingPair)
-        };
+    let (name, value) = match key_value.find('=') {
+        Some(i) => (key_value[..i].trim(), key_value[(i + 1)..].trim()),
+        None => return Err(ParseError::MissingPair)
+    };
 
     if name.is_empty() {
         return Err(ParseError::EmptyName);

--- a/src/secure/key.rs
+++ b/src/secure/key.rs
@@ -1,0 +1,173 @@
+use secure::ring::hkdf::expand;
+use secure::ring::digest::{SHA256, Algorithm};
+use secure::ring::hmac::SigningKey;
+use secure::ring::rand::SystemRandom;
+
+use secure::private::KEY_LEN as PRIVATE_KEY_LEN;
+use secure::signed::KEY_LEN as SIGNED_KEY_LEN;
+
+static HKDF_DIGEST: &'static Algorithm = &SHA256;
+const KEYS_INFO: &'static str = "COOKIE;SIGNED:HMAC-SHA256;PRIVATE:AEAD-AES-256-GCM";
+
+/// A cryptographic master key for use with `Signed` and/or `Private` jars.
+///
+/// This structure encapsulates secure, cryptographic keys for use with both
+/// [PrivateJar](struct.PrivateJar.html) and [SignedJar](struct.SignedJar.html).
+/// It can be derived from a single master key via
+/// [from_master](#method.from_master) or generated from a secure random source
+/// via [generate](#method.generate). A single instance of `Key` can be used for
+/// both a `PrivateJar` and a `SignedJar`.
+///
+/// This type is only available when the `secure` feature is enabled.
+pub struct Key {
+    signing_key: [u8; SIGNED_KEY_LEN],
+    encryption_key: [u8; PRIVATE_KEY_LEN]
+}
+
+impl Key {
+    /// Derives new signing/encryption keys from a master key.
+    ///
+    /// The master key must be at least 256-bits (32 bytes). For security, the
+    /// master key _must_ be cryptographically random. The keys are derived
+    /// deterministically from the master key.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `key` is less than 32 bytes in length.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Key;
+    ///
+    /// # /*
+    /// let master_key = { /* a cryptographically random key >= 32 bytes */ };
+    /// # */
+    /// # let master_key: &Vec<u8> = &(0..32).collect();
+    ///
+    /// let key = Key::from_master(master_key);
+    /// ```
+    pub fn from_master(key: &[u8]) -> Key {
+        if key.len() < 32 {
+            panic!("bad master key length: expected at least 32 bytes, found {}", key.len());
+        }
+
+        // Expand the user's key into two.
+        let prk = SigningKey::new(HKDF_DIGEST, key);
+        let mut both_keys = [0; SIGNED_KEY_LEN + PRIVATE_KEY_LEN];
+        expand(&prk, KEYS_INFO.as_bytes(), &mut both_keys);
+
+        // Copy the keys into their respective arrays.
+        let mut signing_key = [0; SIGNED_KEY_LEN];
+        let mut encryption_key = [0; PRIVATE_KEY_LEN];
+        signing_key.copy_from_slice(&both_keys[..SIGNED_KEY_LEN]);
+        encryption_key.copy_from_slice(&both_keys[SIGNED_KEY_LEN..]);
+
+        Key {
+            signing_key: signing_key,
+            encryption_key: encryption_key
+        }
+    }
+
+    /// Generates signing/encryption keys from a secure, random source. Keys are
+    /// generated nondeterministically.
+    ///
+    /// # Panics
+    ///
+    /// Panics if randomness cannot be retrieved from the operating system. See
+    /// [try_generate](#method.try_generate) for a non-panicking version.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Key;
+    ///
+    /// let key = Key::generate();
+    /// ```
+    pub fn generate() -> Key {
+        Self::try_generate().expect("failed to generate `Key` from randomness")
+    }
+
+    /// Attempts to generate signing/encryption keys from a secure, random
+    /// source. Keys are generated nondeterministically. If randomness cannot be
+    /// retrieved from the underlying operating system, returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Key;
+    ///
+    /// let key = Key::try_generate();
+    /// ```
+    pub fn try_generate() -> Option<Key> {
+        let mut sign_key = [0; SIGNED_KEY_LEN];
+        let mut enc_key = [0; PRIVATE_KEY_LEN];
+
+        let rng = SystemRandom::new();
+        if rng.fill(&mut sign_key).is_err() || rng.fill(&mut enc_key).is_err() {
+            return None
+        }
+
+        Some(Key { signing_key: sign_key, encryption_key: enc_key })
+    }
+
+    /// Returns the raw bytes of a key suitable for signing cookies.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Key;
+    ///
+    /// let key = Key::generate();
+    /// let signing_key = key.signing();
+    /// ```
+    pub fn signing(&self) -> &[u8] {
+        &self.signing_key[..]
+    }
+
+    /// Returns the raw bytes of a key suitable for encrypting cookies.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::Key;
+    ///
+    /// let key = Key::generate();
+    /// let encryption_key = key.encryption();
+    /// ```
+    pub fn encryption(&self) -> &[u8] {
+        &self.encryption_key[..]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Key;
+
+    #[test]
+    fn deterministic_from_master() {
+        let master_key: Vec<u8> = (0..32).collect();
+
+        let key_a = Key::from_master(&master_key);
+        let key_b = Key::from_master(&master_key);
+
+        assert_eq!(key_a.signing(), key_b.signing());
+        assert_eq!(key_a.encryption(), key_b.encryption());
+        assert_ne!(key_a.encryption(), key_a.signing());
+
+        let master_key_2: Vec<u8> = (32..64).collect();
+        let key_2 = Key::from_master(&master_key_2);
+
+        assert_ne!(key_2.signing(), key_a.signing());
+        assert_ne!(key_2.encryption(), key_a.encryption());
+    }
+
+    #[test]
+    fn non_deterministic_generate() {
+        let key_a = Key::generate();
+        let key_b = Key::generate();
+
+        assert_ne!(key_a.signing(), key_b.signing());
+        assert_ne!(key_a.encryption(), key_b.encryption());
+    }
+}

--- a/src/secure/macros.rs
+++ b/src/secure/macros.rs
@@ -1,0 +1,41 @@
+#[cfg(test)]
+macro_rules! assert_simple_behaviour {
+    ($clear:expr, $secure:expr) => ({
+        assert_eq!($clear.iter().count(), 0);
+
+        $secure.add(Cookie::new("name", "val"));
+        assert_eq!($clear.iter().count(), 1);
+        assert_eq!($secure.find("name").unwrap().value(), "val");
+        assert_ne!($clear.find("name").unwrap().value(), "val");
+
+        $secure.add(Cookie::new("another", "two"));
+        assert_eq!($clear.iter().count(), 2);
+
+        $clear.remove(Cookie::named("another"));
+        assert_eq!($clear.iter().count(), 1);
+
+        $secure.remove(Cookie::named("name"));
+        assert_eq!($clear.iter().count(), 0);
+    })
+}
+
+#[cfg(test)]
+macro_rules! assert_secure_behaviour {
+    ($clear:expr, $secure:expr) => ({
+        $secure.add(Cookie::new("secure", "secure"));
+        assert!($clear.find("secure").unwrap().value() != "secure");
+        assert!($secure.find("secure").unwrap().value() == "secure");
+
+        let mut cookie = $clear.find("secure").unwrap().clone();
+        let new_val = format!("{}l", cookie.value());
+        cookie.set_value(new_val);
+        $clear.add(cookie);
+        assert!($secure.find("secure").is_none());
+
+        let mut cookie = $clear.find("secure").unwrap().clone();
+        cookie.set_value("foobar");
+        $clear.add(cookie);
+        assert!($secure.find("secure").is_none());
+    })
+}
+

--- a/src/secure/macros.rs
+++ b/src/secure/macros.rs
@@ -5,8 +5,8 @@ macro_rules! assert_simple_behaviour {
 
         $secure.add(Cookie::new("name", "val"));
         assert_eq!($clear.iter().count(), 1);
-        assert_eq!($secure.find("name").unwrap().value(), "val");
-        assert_ne!($clear.find("name").unwrap().value(), "val");
+        assert_eq!($secure.get("name").unwrap().value(), "val");
+        assert_ne!($clear.get("name").unwrap().value(), "val");
 
         $secure.add(Cookie::new("another", "two"));
         assert_eq!($clear.iter().count(), 2);
@@ -23,19 +23,19 @@ macro_rules! assert_simple_behaviour {
 macro_rules! assert_secure_behaviour {
     ($clear:expr, $secure:expr) => ({
         $secure.add(Cookie::new("secure", "secure"));
-        assert!($clear.find("secure").unwrap().value() != "secure");
-        assert!($secure.find("secure").unwrap().value() == "secure");
+        assert!($clear.get("secure").unwrap().value() != "secure");
+        assert!($secure.get("secure").unwrap().value() == "secure");
 
-        let mut cookie = $clear.find("secure").unwrap().clone();
+        let mut cookie = $clear.get("secure").unwrap().clone();
         let new_val = format!("{}l", cookie.value());
         cookie.set_value(new_val);
         $clear.add(cookie);
-        assert!($secure.find("secure").is_none());
+        assert!($secure.get("secure").is_none());
 
-        let mut cookie = $clear.find("secure").unwrap().clone();
+        let mut cookie = $clear.get("secure").unwrap().clone();
         cookie.set_value("foobar");
         $clear.add(cookie);
-        assert!($secure.find("secure").is_none());
+        assert!($secure.get("secure").is_none());
     })
 }
 

--- a/src/secure/mod.rs
+++ b/src/secure/mod.rs
@@ -1,0 +1,10 @@
+extern crate ring;
+extern crate rustc_serialize;
+
+#[macro_use]
+mod macros;
+mod private;
+mod signed;
+
+pub use self::private::*;
+pub use self::signed::*;

--- a/src/secure/mod.rs
+++ b/src/secure/mod.rs
@@ -5,6 +5,8 @@ extern crate rustc_serialize;
 mod macros;
 mod private;
 mod signed;
+mod key;
 
 pub use self::private::*;
 pub use self::signed::*;
+pub use self::key::*;

--- a/src/secure/private.rs
+++ b/src/secure/private.rs
@@ -1,0 +1,231 @@
+use secure::ring::aead::{seal_in_place, open_in_place, Algorithm, AES_256_GCM};
+use secure::ring::aead::{OpeningKey, SealingKey};
+use secure::ring::rand::SystemRandom;
+
+use secure::rustc_serialize::base64::{ToBase64, FromBase64, STANDARD};
+
+use {Cookie, CookieJar};
+
+// Keep these in sync, and keep the key len synced with the `private` docs.
+static ALGO: &'static Algorithm = &AES_256_GCM;
+const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+const BASE64_NONCE_LEN: usize = 16;
+
+/// Extends `CookieJar` with a `private` method to retrieve a private child jar.
+pub trait Private<'a, 'k> {
+    /// Returns a `PrivateJar` with `self` as its parent jar using the key `key`
+    /// to sign/encrypt and verify/decrypt cookies added/retrieved from the
+    /// child jar. The key must be exactly 32 bytes. For security, the key
+    /// _must_ be cryptographically random.
+    ///
+    /// Any modifications to the child jar will be reflected on the parent jar,
+    /// and any retrievals from the child jar will be made from the parent jar.
+    ///
+    /// This trait is only available when the `secure` feature is enabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `key` is not exactly 32 bytes long.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{Cookie, CookieJar, Private};
+    ///
+    /// // We use a bogus key for demonstration purposes.
+    /// let key: Vec<_> = (0..32).collect();
+    ///
+    /// // Add a private (signed + encrypted) cookie.
+    /// let mut jar = CookieJar::new();
+    /// jar.private(&key).add(Cookie::new("private", "text"));
+    ///
+    /// // The cookie's contents are encrypted.
+    /// assert_ne!(jar.find("private").unwrap().value(), "text");
+    ///
+    /// // They can be decrypted and verified through the child jar.
+    /// assert_eq!(jar.private(&key).find("private").unwrap().value(), "text");
+    ///
+    /// // A tampered with cookie does not validate but still exists.
+    /// let mut cookie = jar.find("private").unwrap().clone();
+    /// jar.add(Cookie::new("private", cookie.value().to_string() + "!"));
+    /// assert!(jar.private(&key).find("private").is_none());
+    /// assert!(jar.find("private").is_some());
+    /// ```
+    fn private(&'a mut self, &'k [u8]) -> PrivateJar<'a, 'k>;
+}
+
+impl<'a, 'k> Private<'a, 'k> for CookieJar {
+    fn private(&'a mut self, key: &'k [u8]) -> PrivateJar<'a, 'k> {
+        if key.len() != KEY_LEN {
+            panic!("bad key length: expected {} bytes, found {}", KEY_LEN, key.len());
+        }
+
+        PrivateJar { parent: self, key: key }
+    }
+}
+
+/// A child cookie jar that provides authenticated encryption for its cookies.
+///
+/// A _private_ child jar signs and encrypts all the cookies added to it and
+/// verifies and decrypts cookies retrieved from it. Any cookies stored in a
+/// `PrivateJar` are simultaneously assured confidentiality, integrity, and
+/// authenticity. In other words, clients cannot discover nor tamper with the
+/// contents of a cookie, nor can they fabricate cookie data.
+///
+/// This type is only available when the `secure` feature is enabled.
+pub struct PrivateJar<'a, 'k> {
+    parent: &'a mut CookieJar,
+    key: &'k [u8]
+}
+
+impl<'a, 'k> PrivateJar<'a, 'k> {
+    /// Given a sealed value `str` where the nonce is prepended to `value`,
+    /// verifies and decrypts the sealed value and returns it. If there's an
+    /// problem, returns an `Err` with a string describing the issue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value.len()` < BASE64_NONCE_LEN.
+    fn unseal(&self, value: &str) -> Result<String, &'static str> {
+        let (nonce_s, sealed_s) = value.split_at(BASE64_NONCE_LEN);
+        let nonce = nonce_s.from_base64().map_err(|_| "bad nonce base64")?;
+        let mut sealed = sealed_s.from_base64().map_err(|_| "bad sealed base64")?;
+        let key = OpeningKey::new(ALGO, self.key).expect("opening key");
+
+        let out_len = open_in_place(&key, &nonce, 0, &mut sealed, &[])
+            .map_err(|_| "invalid key/nonce/value: bad seal")?;
+
+        unsafe { sealed.set_len(out_len); }
+        String::from_utf8(sealed).map_err(|_| "bad unsealed utf8")
+    }
+
+    /// Finds a `Cookie` inside the parent jar with the name `name` and
+    /// authenticates and decrypts the cookie's value, returning a `Cookie` with
+    /// the decrypted value. If the cookie cannot be found, or the cookie fails
+    /// to authenticate or decrypt, `None` is returned.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie, Private};
+    ///
+    /// # let key: Vec<_> = (0..32).collect();
+    /// let mut jar = CookieJar::new();
+    /// let mut private_jar = jar.private(&key);
+    /// assert!(private_jar.find("name").is_none());
+    ///
+    /// private_jar.add(Cookie::new("name", "value"));
+    /// assert_eq!(private_jar.find("name").unwrap().value(), "value");
+    /// ```
+    pub fn find(&self, name: &str) -> Option<Cookie<'static>> {
+        if let Some(cookie_ref) = self.parent.find(name) {
+            let mut cookie = cookie_ref.clone();
+            if cookie.value().len() <= BASE64_NONCE_LEN {
+                return None;
+            }
+
+            if let Ok(value) = self.unseal(cookie.value()) {
+                cookie.set_value(value);
+                return Some(cookie);
+            }
+        }
+
+        None
+    }
+
+    /// Adds `cookie` to the parent jar. The cookie's value is encrypted with
+    /// authenticated encryption assuring confidentiality, integrity, and
+    /// authenticity.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie, Private};
+    ///
+    /// # let key: Vec<_> = (0..32).collect();
+    /// let mut jar = CookieJar::new();
+    /// jar.private(&key).add(Cookie::new("name", "value"));
+    ///
+    /// assert_ne!(jar.find("name").unwrap().value(), "value");
+    /// assert_eq!(jar.private(&key).find("name").unwrap().value(), "value");
+    /// ```
+    pub fn add(&mut self, mut cookie: Cookie<'static>) {
+        // Generate the nonce.
+        let mut nonce = [0; NONCE_LEN];
+        SystemRandom::new().fill(&mut nonce).expect("couldn't randomly fill nonce");
+
+        // Create the `SealingKey` structure.
+        let key = SealingKey::new(ALGO, self.key).expect("sealing key creation");
+
+        // Setup the input and output for the sealing operation.
+        let overhead = ALGO.max_overhead_len();
+        let mut in_out = {
+            let cookie_val = cookie.value().as_bytes();
+            let mut in_out = vec![0; cookie_val.len() + overhead];
+            in_out[..cookie_val.len()].copy_from_slice(cookie_val);
+            in_out
+        };
+
+        // Perform the actual operation and get the output.
+        let out_len = seal_in_place(&key, &nonce, &mut in_out, overhead, &[])
+            .expect("sealing failed!");
+        let sealed_output = &in_out[..out_len];
+        let encrypted_value = sealed_output.to_base64(STANDARD);
+
+        // Build the final cookie value, combining output and nonce.
+        let mut new_value = nonce.to_base64(STANDARD);
+        new_value.push_str(&encrypted_value);
+        cookie.set_value(new_value);
+
+        // Add the sealed cookie to the parent.
+        self.parent.add(cookie);
+    }
+
+    /// Removes `cookie` from the parent jar.
+    ///
+    /// For correct removal, the passed in `cookie` must contain the same `path`
+    /// and `domain` as the cookie that was initially set.
+    ///
+    /// See [CookieJar::remove](struct.CookieJar.html#method.remove) for more
+    /// details.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie, Private};
+    ///
+    /// # let key: Vec<_> = (0..32).collect();
+    /// let mut jar = CookieJar::new();
+    /// let mut private_jar = jar.private(&key);
+    ///
+    /// private_jar.add(Cookie::new("name", "value"));
+    /// assert!(private_jar.find("name").is_some());
+    ///
+    /// private_jar.remove(Cookie::named("name"));
+    /// assert!(private_jar.find("name").is_none());
+    /// ```
+    pub fn remove(&mut self, cookie: Cookie<'static>) {
+        self.parent.remove(cookie);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Private;
+    use {CookieJar, Cookie};
+
+    #[test]
+    fn simple() {
+        let key: Vec<u8> = (0..super::KEY_LEN as u8).collect();
+        let mut jar = CookieJar::new();
+        assert_simple_behaviour!(jar, jar.private(&key));
+    }
+
+    #[test]
+    fn private() {
+        let key: Vec<u8> = (0..super::KEY_LEN as u8).collect();
+        let mut jar = CookieJar::new();
+        assert_secure_behaviour!(jar, jar.private(&key));
+    }
+}

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -1,0 +1,206 @@
+use secure::ring::digest::{SHA256, Algorithm};
+use secure::ring::hmac::{SigningKey, sign, verify_with_own_key as verify};
+
+use secure::rustc_serialize::base64::{ToBase64, FromBase64, STANDARD};
+
+use {Cookie, CookieJar};
+
+// Keep these three in sync, and keep the key len synced with the `signed` docs.
+static DIGEST: &'static Algorithm = &SHA256;
+const BASE64_DIGEST_LEN: usize = 44;
+const KEY_LEN: usize = 64;
+
+/// Extends `CookieJar` with a `signed` method to retrieve a signed child jar.
+pub trait Signed<'a, 'k> {
+    /// Returns a `SignedJar` with `self` as its parent jar using the key `key`
+    /// to sign/verify cookies added/retrieved from the child jar. The key must
+    /// be exactly 64 bytes. For security, the key _must_ be cryptographically
+    /// random.
+    ///
+    /// Any modifications to the child jar will be reflected on the parent jar,
+    /// and any retrievals from the child jar will be made from the parent jar.
+    ///
+    /// This trait is only available when the `secure` feature is enabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `key` is not exactly 64 bytes long.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{Cookie, CookieJar, Signed};
+    ///
+    /// // We use a bogus key for demonstration purposes.
+    /// let key: Vec<_> = (0..64).collect();
+    ///
+    /// // Add a signed cookie.
+    /// let mut jar = CookieJar::new();
+    /// jar.signed(&key).add(Cookie::new("signed", "text"));
+    ///
+    /// // The cookie's contents are signed but still in plaintext.
+    /// assert_ne!(jar.find("signed").unwrap().value(), "text");
+    /// assert!(jar.find("signed").unwrap().value().contains("text"));
+    ///
+    /// // They can be verified through the child jar.
+    /// assert_eq!(jar.signed(&key).find("signed").unwrap().value(), "text");
+    ///
+    /// // A tampered with cookie does not validate but still exists.
+    /// let mut cookie = jar.find("signed").unwrap().clone();
+    /// jar.add(Cookie::new("signed", cookie.value().to_string() + "!"));
+    /// assert!(jar.signed(&key).find("signed").is_none());
+    /// assert!(jar.find("signed").is_some());
+    /// ```
+    fn signed(&'a mut self, key: &'k [u8]) -> SignedJar<'a, 'k>;
+}
+
+impl<'a, 'k> Signed<'a, 'k> for CookieJar {
+    fn signed(&'a mut self, key: &'k [u8]) -> SignedJar<'a, 'k> {
+        if key.len() != KEY_LEN {
+            panic!("bad key length: expected {} bytes, found {}", KEY_LEN, key.len());
+        }
+
+        SignedJar { parent: self, key: key }
+    }
+}
+
+/// A child cookie jar that authenticates its cookies.
+///
+/// A _signed_ child jar signs all the cookies added to it and verifies cookies
+/// retrieved from it. Any cookies stored in a `SignedJar` are assured integrity
+/// and authenticity. In other words, clients cannot tamper with the contents of
+/// a cookie nor can they fabricate cookie values, but the data is visible in
+/// plaintext.
+///
+/// This type is only available when the `secure` feature is enabled.
+pub struct SignedJar<'a, 'k> {
+    parent: &'a mut CookieJar,
+    key: &'k [u8]
+}
+
+impl<'a, 'k> SignedJar<'a, 'k> {
+    /// Given a signed value `str` where the signature is prepended to `value`,
+    /// verifies the signed value and returns it. If there's a problem, returns
+    /// an `Err` with a string describing the issue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value.len()` < BASE64_DIGEST_LEN.
+    fn verify(&self, cookie_value: &str) -> Result<String, &'static str> {
+        let (digest_str, value) = cookie_value.split_at(BASE64_DIGEST_LEN);
+        let key = SigningKey::new(DIGEST, self.key);
+        let sig = digest_str.from_base64().map_err(|_| "bad base64 digest")?;
+
+        verify(&key, value.as_bytes(), &sig)
+            .map(|_| value.to_string())
+            .map_err(|_| "value did not verify")
+    }
+
+    /// Finds a `Cookie` inside the parent jar with the name `name` and verifies
+    /// the authenticity and integrity of the cookie's value, returning a
+    /// `Cookie` with the authenticated value. If the cookie cannot be found, or
+    /// the cookie fails to verify, `None` is returned.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie, Signed};
+    ///
+    /// # let key: Vec<_> = (0..64).collect();
+    /// let mut jar = CookieJar::new();
+    /// let mut signed_jar = jar.signed(&key);
+    /// assert!(signed_jar.find("name").is_none());
+    ///
+    /// signed_jar.add(Cookie::new("name", "value"));
+    /// assert_eq!(signed_jar.find("name").unwrap().value(), "value");
+    /// ```
+    pub fn find(&self, name: &str) -> Option<Cookie<'static>> {
+        if let Some(cookie_ref) = self.parent.find(name) {
+            let mut cookie = cookie_ref.clone();
+            if cookie.value().len() < BASE64_DIGEST_LEN {
+                return None;
+            }
+
+            if let Ok(value) = self.verify(cookie.value()) {
+                cookie.set_value(value);
+                return Some(cookie);
+            }
+        }
+
+        None
+    }
+
+    /// Adds `cookie` to the parent jar. The cookie's value is signed assuring
+    /// integrity and authenticity.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie, Signed};
+    ///
+    /// # let key: Vec<_> = (0..64).collect();
+    /// let mut jar = CookieJar::new();
+    /// jar.signed(&key).add(Cookie::new("name", "value"));
+    ///
+    /// assert_ne!(jar.find("name").unwrap().value(), "value");
+    /// assert!(jar.find("name").unwrap().value().contains("value"));
+    /// assert_eq!(jar.signed(&key).find("name").unwrap().value(), "value");
+    /// ```
+    pub fn add(&mut self, mut cookie: Cookie<'static>) {
+        let key = SigningKey::new(DIGEST, self.key);
+        let digest = sign(&key, cookie.value().as_bytes());
+
+        let mut new_value = digest.as_ref().to_base64(STANDARD);
+        new_value.push_str(cookie.value());
+        cookie.set_value(new_value);
+
+        self.parent.add(cookie);
+    }
+
+    /// Removes `cookie` from the parent jar.
+    ///
+    /// For correct removal, the passed in `cookie` must contain the same `path`
+    /// and `domain` as the cookie that was initially set.
+    ///
+    /// See [CookieJar::remove](struct.CookieJar.html#method.remove) for more
+    /// details.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie, Signed};
+    ///
+    /// # let key: Vec<_> = (0..64).collect();
+    /// let mut jar = CookieJar::new();
+    /// let mut signed_jar = jar.signed(&key);
+    ///
+    /// signed_jar.add(Cookie::new("name", "value"));
+    /// assert!(signed_jar.find("name").is_some());
+    ///
+    /// signed_jar.remove(Cookie::named("name"));
+    /// assert!(signed_jar.find("name").is_none());
+    /// ```
+    pub fn remove(&mut self, cookie: Cookie<'static>) {
+        self.parent.remove(cookie);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Signed;
+    use {CookieJar, Cookie};
+
+    #[test]
+    fn simple() {
+        let key: Vec<u8> = (0..super::KEY_LEN as u8).collect();
+        let mut jar = CookieJar::new();
+        assert_simple_behaviour!(jar, jar.signed(&key));
+    }
+
+    #[test]
+    fn private() {
+        let key: Vec<u8> = (0..super::KEY_LEN as u8).collect();
+        let mut jar = CookieJar::new();
+        assert_secure_behaviour!(jar, jar.signed(&key));
+    }
+}

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -8,7 +8,7 @@ use {Cookie, CookieJar};
 // Keep these three in sync, and keep the key len synced with the `signed` docs.
 static DIGEST: &'static Algorithm = &SHA256;
 const BASE64_DIGEST_LEN: usize = 44;
-const KEY_LEN: usize = 64;
+const KEY_LEN: usize = 32;
 
 /// A child cookie jar that authenticates its cookies.
 ///
@@ -31,7 +31,7 @@ impl<'a> SignedJar<'a> {
     ///
     /// # Panics
     ///
-    /// Panics if `key` is not exactly 64 bytes long.
+    /// Panics if `key` is not exactly 32 bytes long.
     #[doc(hidden)]
     pub fn new(parent: &'a mut CookieJar, key: &[u8]) -> SignedJar<'a> {
         if key.len() != KEY_LEN {
@@ -67,7 +67,7 @@ impl<'a> SignedJar<'a> {
     /// ```rust
     /// use cookie::{CookieJar, Cookie};
     ///
-    /// # let key: Vec<_> = (0..64).collect();
+    /// # let key: Vec<_> = (0..32).collect();
     /// let mut jar = CookieJar::new();
     /// let mut signed_jar = jar.signed(&key);
     /// assert!(signed_jar.get("name").is_none());
@@ -95,7 +95,7 @@ impl<'a> SignedJar<'a> {
     /// ```rust
     /// use cookie::{CookieJar, Cookie};
     ///
-    /// # let key: Vec<_> = (0..64).collect();
+    /// # let key: Vec<_> = (0..32).collect();
     /// let mut jar = CookieJar::new();
     /// jar.signed(&key).add(Cookie::new("name", "value"));
     ///
@@ -125,7 +125,7 @@ impl<'a> SignedJar<'a> {
     /// ```rust
     /// use cookie::{CookieJar, Cookie};
     ///
-    /// # let key: Vec<_> = (0..64).collect();
+    /// # let key: Vec<_> = (0..32).collect();
     /// let mut jar = CookieJar::new();
     /// let mut signed_jar = jar.signed(&key);
     ///

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -39,17 +39,17 @@ pub trait Signed<'a, 'k> {
     /// jar.signed(&key).add(Cookie::new("signed", "text"));
     ///
     /// // The cookie's contents are signed but still in plaintext.
-    /// assert_ne!(jar.find("signed").unwrap().value(), "text");
-    /// assert!(jar.find("signed").unwrap().value().contains("text"));
+    /// assert_ne!(jar.get("signed").unwrap().value(), "text");
+    /// assert!(jar.get("signed").unwrap().value().contains("text"));
     ///
     /// // They can be verified through the child jar.
-    /// assert_eq!(jar.signed(&key).find("signed").unwrap().value(), "text");
+    /// assert_eq!(jar.signed(&key).get("signed").unwrap().value(), "text");
     ///
     /// // A tampered with cookie does not validate but still exists.
-    /// let mut cookie = jar.find("signed").unwrap().clone();
+    /// let mut cookie = jar.get("signed").unwrap().clone();
     /// jar.add(Cookie::new("signed", cookie.value().to_string() + "!"));
-    /// assert!(jar.signed(&key).find("signed").is_none());
-    /// assert!(jar.find("signed").is_some());
+    /// assert!(jar.signed(&key).get("signed").is_none());
+    /// assert!(jar.get("signed").is_some());
     /// ```
     fn signed(&'a mut self, key: &'k [u8]) -> SignedJar<'a, 'k>;
 }
@@ -96,10 +96,10 @@ impl<'a, 'k> SignedJar<'a, 'k> {
             .map_err(|_| "value did not verify")
     }
 
-    /// Finds a `Cookie` inside the parent jar with the name `name` and verifies
-    /// the authenticity and integrity of the cookie's value, returning a
-    /// `Cookie` with the authenticated value. If the cookie cannot be found, or
-    /// the cookie fails to verify, `None` is returned.
+    /// Returns a reference to the `Cookie` inside this jar with the name `name`
+    /// and verifies the authenticity and integrity of the cookie's value,
+    /// returning a `Cookie` with the authenticated value. If the cookie cannot
+    /// be found, or the cookie fails to verify, `None` is returned.
     ///
     /// # Example
     ///
@@ -109,13 +109,13 @@ impl<'a, 'k> SignedJar<'a, 'k> {
     /// # let key: Vec<_> = (0..64).collect();
     /// let mut jar = CookieJar::new();
     /// let mut signed_jar = jar.signed(&key);
-    /// assert!(signed_jar.find("name").is_none());
+    /// assert!(signed_jar.get("name").is_none());
     ///
     /// signed_jar.add(Cookie::new("name", "value"));
-    /// assert_eq!(signed_jar.find("name").unwrap().value(), "value");
+    /// assert_eq!(signed_jar.get("name").unwrap().value(), "value");
     /// ```
-    pub fn find(&self, name: &str) -> Option<Cookie<'static>> {
-        if let Some(cookie_ref) = self.parent.find(name) {
+    pub fn get(&self, name: &str) -> Option<Cookie<'static>> {
+        if let Some(cookie_ref) = self.parent.get(name) {
             let mut cookie = cookie_ref.clone();
             if cookie.value().len() < BASE64_DIGEST_LEN {
                 return None;
@@ -142,9 +142,9 @@ impl<'a, 'k> SignedJar<'a, 'k> {
     /// let mut jar = CookieJar::new();
     /// jar.signed(&key).add(Cookie::new("name", "value"));
     ///
-    /// assert_ne!(jar.find("name").unwrap().value(), "value");
-    /// assert!(jar.find("name").unwrap().value().contains("value"));
-    /// assert_eq!(jar.signed(&key).find("name").unwrap().value(), "value");
+    /// assert_ne!(jar.get("name").unwrap().value(), "value");
+    /// assert!(jar.get("name").unwrap().value().contains("value"));
+    /// assert_eq!(jar.signed(&key).get("name").unwrap().value(), "value");
     /// ```
     pub fn add(&mut self, mut cookie: Cookie<'static>) {
         let key = SigningKey::new(DIGEST, self.key);
@@ -175,10 +175,10 @@ impl<'a, 'k> SignedJar<'a, 'k> {
     /// let mut signed_jar = jar.signed(&key);
     ///
     /// signed_jar.add(Cookie::new("name", "value"));
-    /// assert!(signed_jar.find("name").is_some());
+    /// assert!(signed_jar.get("name").is_some());
     ///
     /// signed_jar.remove(Cookie::named("name"));
-    /// assert!(signed_jar.find("name").is_none());
+    /// assert!(signed_jar.get("name").is_none());
     /// ```
     pub fn remove(&mut self, cookie: Cookie<'static>) {
         self.parent.remove(cookie);

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -6,7 +6,7 @@ use secure::rustc_serialize::base64::{ToBase64, FromBase64, STANDARD};
 use {Cookie, CookieJar};
 
 // Keep these three in sync, and keep the key len synced with the `signed` docs.
-static DIGEST: &'static Algorithm = &SHA256;
+static HMAC_DIGEST: &'static Algorithm = &SHA256;
 const BASE64_DIGEST_LEN: usize = 44;
 const KEY_LEN: usize = 32;
 
@@ -38,7 +38,7 @@ impl<'a> SignedJar<'a> {
             panic!("bad key length: expected {} bytes, found {}", KEY_LEN, key.len());
         }
 
-        SignedJar { parent: parent, key: SigningKey::new(DIGEST, key) }
+        SignedJar { parent: parent, key: SigningKey::new(HMAC_DIGEST, key) }
     }
 
     /// Given a signed value `str` where the signature is prepended to `value`,


### PR DESCRIPTION
This commit completely rewrites `CookieJar` so that it is more efficient while being simpler and more correct overall. At a high-level, a `CookieJar` now returns borrows to `Cookie` structures whenever possible. `CookieJar` and children jars (now `PrivateJar` and `SignedJar`) are distinct types. The "encrypted" child jar has been replaced by `PrivateJar` which uses authenticated encryption. All crypto is done via `ring`.

A detailed list of changes is below:

  * The "permanent" child jar has been removed.
  * A `make_permanent` method has been added to `Cookie`.
  * A `permanent` method has been added to `CookieBuilder`.
  * A `named` constructor has been added to `Cookie`.
  * `CookieJar` no longer has a generic lifetime parameter.
  * A `CookieJar` no longer contains `RefCell`s.
  * `CookieJar::{add_original, add, remove, clear}` take `&mut self`.
  * `CookieJar::new` does not take in a `key` parameter.
  * `CookieJar::find` returns a borrow to a `Cookie`.
  * `CookieJar::remove` takes in a `Cookie`.
  * `CookieJar::clear` has been deprecated.
  * A `CookieJar` tracks its modifications more robustly, passing a new suite of unit tests.
  * Computing the `delta` is zero-cost operation.
  * Cookie iteration is significantly simplified.
  * The `signed` method has been removed from `CookieJar`.
  * A new `Signed` trait was added with a `signed(&key)` method.
  * The `Signed` trait is implemented for `CookieJar`.
  * `SignedJar` cookies sign via ring's HMAC-SHA256 implementation.
  * The `encrypted` method has been removed from `CookieJar`.
  * A new `Private` trait was added with a `private(&key)` method.
  * The `Private` trait is implemented for `CookieJar`.
  * `PrivateJar` cookies use AEAD (AES-256-GCM) from ring.
  * The `openssl` dependency was dropped.
  * A `ring` dependency was introduced.
  * All items are extensively documented.

Fixes #35.
Fixes #50.
Fixes #64.
Closes #68.
Fixes #75.

Finally, I'd like to, once again, request that I be given maintainer access to the repository/crate. I'd really like to continue improving and maintaining this crate in the future.