### PR TITLE
Switch from time to chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ secure = ["ring", "base64"]
 percent-encode = ["url"]
 
 [dependencies]
-time = "0.1"
+chrono = "0.3.1"
 url = { version = "1.0", optional = true }
 ring = { version = "0.7.4", optional = true }
 base64 = { version = "0.4", optional = true }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use time::{Tm, Duration};
+use chrono::{DateTime, Duration, UTC};
 
 use ::{Cookie, SameSite};
 
@@ -15,11 +15,11 @@ use ::{Cookie, SameSite};
 /// # Example
 ///
 /// ```rust
+/// extern crate chrono;
 /// # extern crate cookie;
-/// extern crate time;
 ///
 /// use cookie::Cookie;
-/// use time::Duration;
+/// use chrono::Duration;
 ///
 /// # fn main() {
 /// let cookie: Cookie = Cookie::build("name", "value")
@@ -64,20 +64,20 @@ impl CookieBuilder {
     ///
     /// ```rust
     /// # extern crate cookie;
-    /// extern crate time;
+    /// extern crate chrono;
     ///
     /// use cookie::Cookie;
     ///
     /// # fn main() {
     /// let c = Cookie::build("foo", "bar")
-    ///     .expires(time::now())
+    ///     .expires(chrono::UTC::now())
     ///     .finish();
     ///
     /// assert!(c.expires().is_some());
     /// # }
     /// ```
     #[inline]
-    pub fn expires(mut self, when: Tm) -> CookieBuilder {
+    pub fn expires(mut self, when: DateTime<UTC>) -> CookieBuilder {
         self.cookie.set_expires(when);
         self
     }
@@ -87,10 +87,10 @@ impl CookieBuilder {
     /// # Example
     ///
     /// ```rust
+    /// extern crate chrono;
     /// # extern crate cookie;
-    /// extern crate time;
-    /// use time::Duration;
     ///
+    /// use chrono::Duration;
     /// use cookie::Cookie;
     ///
     /// # fn main() {
@@ -206,11 +206,11 @@ impl CookieBuilder {
     /// # Example
     ///
     /// ```rust
+    /// extern crate chrono;
     /// # extern crate cookie;
-    /// extern crate time;
     ///
+    /// use chrono::Duration;
     /// use cookie::Cookie;
-    /// use time::Duration;
     ///
     /// # fn main() {
     /// let c = Cookie::build("foo", "bar")

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::mem::replace;
 
-use time::{self, Duration};
+use chrono::{self, Duration};
 
 #[cfg(feature = "secure")]
 use secure::{PrivateJar, SignedJar, Key};
@@ -182,11 +182,11 @@ impl CookieJar {
     /// Removing an _original_ cookie results in a _removal_ cookie:
     ///
     /// ```rust
+    /// extern crate chrono;
     /// # extern crate cookie;
-    /// extern crate time;
     ///
     /// use cookie::{CookieJar, Cookie};
-    /// use time::Duration;
+    /// use chrono::Duration;
     ///
     /// # fn main() {
     /// let mut jar = CookieJar::new();
@@ -221,7 +221,7 @@ impl CookieJar {
         fn make_removal_cookie(mut cookie: Cookie<'static>) -> DeltaCookie {
             cookie.set_value("");
             cookie.set_max_age(Duration::seconds(0));
-            cookie.set_expires(time::now() - Duration::days(365));
+            cookie.set_expires(chrono::UTC::now() - Duration::days(365));
             DeltaCookie::removed(cookie)
         }
 
@@ -491,7 +491,7 @@ mod test {
     #[cfg(feature = "secure")]
     fn delta() {
         use std::collections::HashMap;
-        use time::Duration;
+        use chrono::Duration;
 
         let mut c = CookieJar::new();
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,7 +7,7 @@ use std::convert::From;
 
 #[cfg(feature = "percent-encode")]
 use url::percent_encoding::percent_decode;
-use time::{self, Duration};
+use chrono::{Duration, TimeZone, UTC};
 
 use ::{Cookie, SameSite, CookieStr};
 
@@ -185,12 +185,12 @@ fn parse_inner<'c>(s: &str, decode: bool) -> Result<Cookie<'c>, ParseError> {
                 // Try strptime with three date formats according to
                 // http://tools.ietf.org/html/rfc2616#section-3.3.1. Try
                 // additional ones as encountered in the real world.
-                let tm = time::strptime(v, "%a, %d %b %Y %H:%M:%S %Z")
-                    .or_else(|_| time::strptime(v, "%A, %d-%b-%y %H:%M:%S %Z"))
-                    .or_else(|_| time::strptime(v, "%a, %d-%b-%Y %H:%M:%S %Z"))
-                    .or_else(|_| time::strptime(v, "%a %b %d %H:%M:%S %Y"));
+                let time = UTC.datetime_from_str(v, "%a, %d %b %Y %H:%M:%S GMT")
+                    .or_else(|_| UTC.datetime_from_str(v, "%A, %d-%b-%y %H:%M:%S GMT"))
+                    .or_else(|_| UTC.datetime_from_str(v, "%a, %d-%b-%Y %H:%M:%S GMT"))
+                    .or_else(|_| UTC.datetime_from_str(v, "%a %b %d %H:%M:%S %Y"));
 
-                if let Ok(time) = tm {
+                if let Ok(time) = time {
                     cookie.expires = Some(time)
                 }
             }
@@ -218,7 +218,7 @@ pub fn parse_cookie<'c, S>(cow: S, decode: bool) -> Result<Cookie<'c>, ParseErro
 #[cfg(test)]
 mod tests {
     use ::{Cookie, SameSite};
-    use ::time::{strptime, Duration};
+    use chrono::{Duration, TimeZone, UTC};
 
     macro_rules! assert_eq_parse {
         ($string:expr, $expected:expr) => (
@@ -363,13 +363,13 @@ mod tests {
             Domain=FOO.COM", unexpected);
 
         let time_str = "Wed, 21 Oct 2015 07:28:00 GMT";
-        let expires = strptime(time_str, "%a, %d %b %Y %H:%M:%S %Z").unwrap();
+        let expires = UTC.datetime_from_str(time_str, "%a, %d %b %Y %H:%M:%S GMT").unwrap();
         expected.set_expires(expires);
         assert_eq_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
             Domain=foo.com; Expires=Wed, 21 Oct 2015 07:28:00 GMT", expected);
 
         unexpected.set_domain("foo.com");
-        let bad_expires = strptime(time_str, "%a, %d %b %Y %H:%S:%M %Z").unwrap();
+        let bad_expires = UTC.datetime_from_str(time_str, "%a, %d %b %Y %H:%S:%M GMT").unwrap();
         expected.set_expires(bad_expires);
         assert_ne_parse!(" foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
             Domain=foo.com; Expires=Wed, 21 Oct 2015 07:28:00 GMT", unexpected);


### PR DESCRIPTION
This is a breaking change. The time module is deprecated, and suggests switching over to the chrono library, which is more actively maintained. One thing to note is that chrono does not support parsing with `%Z`:

https://github.com/chronotope/chrono/issues/38

However, this actually isn't that bad. According to RFC 2616, the only supported timezone is "GMT":

http://tools.ietf.org/html/rfc2616#section-3.3.1

Furthermore, @lifthrasiir points out that most implementations of `%Z` is actually not widely supported. On my mac, it claims to only support parsing the local timezone, and GMT, so I believe it's safe to hardcode the timezone.

This also fixes a bug in an example, where October 21, 2017 would be a Saturday. However, Wednesday 21 October, 2015 is Back to the Future day, so this switches to using that date instead.