### PR TITLE
Don't panic if passed in a large max age.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/cookie/0.6")]
+#![allow(deprecated)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
Duration will panic if the number of seconds is greater than 2^63/1000. This just caps the Max-Age to the highest value we can parse.