### PR TITLE
0.8.0: Update to base64 0.5.2 and *ring* 0.9.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "cookie"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Sergio Benitez <sb@sergio.bz>"]
-version = "0.7.6"
+version = "0.8.0"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/cookie-rs"
 documentation = "https://docs.rs/cookie"
@@ -18,5 +18,5 @@ percent-encode = ["url"]
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-ring = { version = "0.7.4", optional = true }
-base64 = { version = "0.4", optional = true }
+ring = { version = "0.9.1", optional = true }
+base64 = { version = "0.5.2", optional = true }

--- a/src/secure/key.rs
+++ b/src/secure/key.rs
@@ -1,7 +1,7 @@
 use secure::ring::hkdf::expand;
 use secure::ring::digest::{SHA256, Algorithm};
 use secure::ring::hmac::SigningKey;
-use secure::ring::rand::SystemRandom;
+use secure::ring::rand::{SecureRandom, SystemRandom};
 
 use secure::private::KEY_LEN as PRIVATE_KEY_LEN;
 use secure::signed::KEY_LEN as SIGNED_KEY_LEN;

--- a/src/secure/private.rs
+++ b/src/secure/private.rs
@@ -1,6 +1,6 @@
 use secure::ring::aead::{seal_in_place, open_in_place, Algorithm, AES_256_GCM};
 use secure::ring::aead::{OpeningKey, SealingKey};
-use secure::ring::rand::SystemRandom;
+use secure::ring::rand::{SecureRandom, SystemRandom};
 use secure::{base64, Key};
 
 use {Cookie, CookieJar};


### PR DESCRIPTION
base64 0.5.2 fixes a security vulnerability. *ring* 0.9 is used by the
latest version of Rustls and some other crates.