### PR TITLE
Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ percent-encode = ["url"]
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-ring = { version = "0.9.1", optional = true }
+ring = { version = "0.9.4", optional = true }
 base64 = { version = "0.5.2", optional = true }


### PR DESCRIPTION
Before ring 0.9.3, it was possible to link multiple versions of ring into a program, e.g. if one version depended on ring 0.6 and another dependend on ring 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link ring's C/asm code correctly in that kind of situation. ring 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of ring to be linked into the same program, to prevent any problems this may cause.

ring 0.9.4 was released with an update to make some crates easier to update to 0.9.x.