### PR TITLE
upgrade ring to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ percent-encode = ["url"]
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-ring = { version = "0.9.4", optional = true }
+ring = { version = "0.11.0", optional = true }
 base64 = { version = "0.5.2", optional = true }


### PR DESCRIPTION
Please upgrade ring. I'm having to manually freeze another project of mine to 9.4 that is using ring 0.11.0. Thanks.