### PR TITLE
add add_original to private and signed jars

### DIFF
--- a/src/secure/private.rs
+++ b/src/secure/private.rs
@@ -110,7 +110,16 @@ impl<'a> PrivateJar<'a> {
         self.parent.add(cookie);
     }
 
-    /// Adds an "original" `cookie` to this jar.
+    /// Adds an "original" `cookie` to parent jar.
+    /// The cookie's value is encrypted with authenticated encryption
+    /// assuring confidentiality, integrity, and authenticity.
+    /// Adding an original cookie does not affect the
+    /// [CookieJar::delta](struct.CookieJar.html#method.delta) computation.
+    /// This method is intended to be used to seed the cookie jar
+    /// with cookies received from a client's HTTP message.
+    ///
+    /// For accurate `delta` computations, this method should not be called
+    /// after calling `remove`.
     /// 
     /// # Example
     /// 

--- a/src/secure/private.rs
+++ b/src/secure/private.rs
@@ -110,7 +110,20 @@ impl<'a> PrivateJar<'a> {
         self.parent.add(cookie);
     }
 
-    /// Same as add, but adds original `cookie`
+    /// Adds an "original" `cookie` to this jar.
+    /// 
+    /// # Example
+    /// 
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie, Key};
+    ///
+    /// let key = Key::generate();
+    /// let mut jar = CookieJar::new();
+    /// jar.private(&key).add_original(Cookie::new("name", "value"));
+    ///
+    /// assert_eq!(jar.iter().count(), 1);
+    /// assert_eq!(jar.delta().count(), 0);
+    /// ```
     pub fn add_original(&mut self, mut cookie: Cookie<'static>) {
         self.encrypt_cookie(&mut cookie);
 

--- a/src/secure/private.rs
+++ b/src/secure/private.rs
@@ -104,6 +104,23 @@ impl<'a> PrivateJar<'a> {
     /// assert_eq!(jar.private(&key).get("name").unwrap().value(), "value");
     /// ```
     pub fn add(&mut self, mut cookie: Cookie<'static>) {
+        self.encrypt_cookie(&mut cookie);
+
+        // Add the sealed cookie to the parent.
+        self.parent.add(cookie);
+    }
+
+    /// Same as add, but adds original `cookie`
+    pub fn add_original(&mut self, mut cookie: Cookie<'static>) {
+        self.encrypt_cookie(&mut cookie);
+
+        // Add the sealed cookie to the parent.
+        self.parent.add_original(cookie);
+    }
+
+    /// Encrypts the cookie's value with
+    /// authenticated encryption assuring confidentiality, integrity, and authenticity.
+    fn encrypt_cookie(&self, cookie: &mut Cookie) {
         let mut data;
         let output_len = {
             // Create the `SealingKey` structure.
@@ -129,9 +146,6 @@ impl<'a> PrivateJar<'a> {
         // Base64 encode the nonce and encrypted value.
         let sealed_value = base64::encode(&data[..(NONCE_LEN + output_len)]);
         cookie.set_value(sealed_value);
-
-        // Add the sealed cookie to the parent.
-        self.parent.add(cookie);
     }
 
     /// Removes `cookie` from the parent jar.

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -96,12 +96,22 @@ impl<'a> SignedJar<'a> {
     /// assert_eq!(jar.signed(&key).get("name").unwrap().value(), "value");
     /// ```
     pub fn add(&mut self, mut cookie: Cookie<'static>) {
+        self.sign_cookie(&mut cookie);
+        self.parent.add(cookie);
+    }
+
+    /// Same as add, but add cookie as original to parent jar
+    pub fn add_original(&mut self, mut cookie: Cookie<'static>) {
+        self.sign_cookie(&mut cookie);
+        self.parent.add_original(cookie);
+    }
+
+    /// Signs the cookie's value assuring integrity and authenticity.
+    fn sign_cookie(&self, cookie: &mut Cookie) {
         let digest = sign(&self.key, cookie.value().as_bytes());
         let mut new_value = base64::encode(digest.as_ref());
         new_value.push_str(cookie.value());
         cookie.set_value(new_value);
-
-        self.parent.add(cookie);
     }
 
     /// Removes `cookie` from the parent jar.

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -101,6 +101,14 @@ impl<'a> SignedJar<'a> {
     }
 
     /// Adds an "original" `cookie` to this jar.
+    /// The cookie's value is signed assuring integrity and authenticity.
+    /// Adding an original cookie does not affect the
+    /// [CookieJar::delta](struct.CookieJar.html#method.delta) computation.
+    /// This method is intended to be used to seed the cookie jar
+    /// with cookies received from a client's HTTP message.
+    ///
+    /// For accurate `delta` computations, this method should not be called
+    /// after calling `remove`.
     /// 
     /// # Example
     /// 

--- a/src/secure/signed.rs
+++ b/src/secure/signed.rs
@@ -100,7 +100,20 @@ impl<'a> SignedJar<'a> {
         self.parent.add(cookie);
     }
 
-    /// Same as add, but add cookie as original to parent jar
+    /// Adds an "original" `cookie` to this jar.
+    /// 
+    /// # Example
+    /// 
+    /// ```rust
+    /// use cookie::{CookieJar, Cookie, Key};
+    ///
+    /// let key = Key::generate();
+    /// let mut jar = CookieJar::new();
+    /// jar.signed(&key).add_original(Cookie::new("name", "value"));
+    /// 
+    /// assert_eq!(jar.iter().count(), 1);
+    /// assert_eq!(jar.delta().count(), 0);
+    /// ```
     pub fn add_original(&mut self, mut cookie: Cookie<'static>) {
         self.sign_cookie(&mut cookie);
         self.parent.add_original(cookie);


### PR DESCRIPTION
Hi.
While trying to make a pr for this issue https://github.com/SergioBenitez/Rocket/issues/368 I found out that it requires to add original cookie for a `PrivateJar`.

I realised that `add_original` method is missing for some reason. Do you find it suitable to be added to `PrivateJar` and `SignedJar`?