### PR TITLE
Bump ring to fix build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ percent-encode = ["url"]
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-ring = { version = "0.13.0-alpha", optional = true }
+ring = { version = "0.13.0-alpha5", optional = true }
 base64 = { version = "0.9.0", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
alpha3 fixed a bug that caused a build error on windows (https://github.com/briansmith/ring/commit/40963edc4e4b66922529227019a8654e80bd8d25).