### PR TITLE
update ring to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ percent-encode = ["url"]
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-ring = { version = "0.13.0-alpha", optional = true }
+ring = { version = "0.13.0", optional = true }
 base64 = { version = "0.9.0", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
ring published 0.13 today. The new version fixes the windows compilation issues that were present in 0.12.1 which means that cookie will be able to build on windows again.