### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ percent-encode = ["url"]
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-ring = { version = "0.13.0", optional = true }
-base64 = { version = "0.9.0", optional = true }
+ring = { version = "0.14.0", optional = true }
+base64 = { version = "0.10.0", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This updates both the ring and base64 dependency. The ring dependency is especially imported for me since 0.14 contains important bugfixes that I can't use until every crate in my dependency tree is on 0.14. :)

Related to: https://github.com/SergioBenitez/Rocket/issues/905 and https://github.com/kpcyrd/sn0int/issues/69

Thanks!