### PR TITLE
Drop build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/SergioBenitez/cookie-rs"
 documentation = "https://docs.rs/cookie"
 readme = "README.md"
-build = "build.rs"
 description = """
 HTTP cookie parsing and cookie jar management. Supports signed and private
 (encrypted, authenticated) jars.
@@ -33,8 +32,6 @@ rand = { version = "0.8", optional = true }
 hkdf = { version = "0.12.0", optional = true }
 subtle = { version = "2.3", optional = true }
 
-[build-dependencies]
-version_check = "0.9.4"
-
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,0 @@
-fn main() {
-    if let Some(true) = version_check::supports_feature("doc_cfg") {
-        println!("cargo:rustc-cfg=nightly");
-    }
-}


### PR DESCRIPTION
While looking at uses of build script in my dependency tree, I've realized that this crate uses a build script just to turn on the `doc_cfg` nightly feature. Most other crates instead solve this problem by using `rustdoc-args` in the docs.rs config. This switches to that, removing the build script and the dependency on `version_check`.