### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = """
 HTTP cookie parsing and cookie jar management. Supports signed and private
 (encrypted, authenticated) jars.
 """
+include = ["Cargo.toml", "CHANGELOG.md", "README.md", "LICENSE-APACHE", "LICENSE-MIT", "build.rs", "src/**/*.rs"]
 
 [features]
 percent-encode = ["percent-encoding"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ version_check = "0.9.4"
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }

--- a/src/jar.rs
+++ b/src/jar.rs
@@ -340,7 +340,7 @@ impl CookieJar {
     /// // Delta contains two new cookies ("new", "yac") and a removal ("name").
     /// assert_eq!(jar.delta().count(), 3);
     /// ```
-    pub fn delta(&self) -> Delta {
+    pub fn delta(&self) -> Delta<'_> {
         Delta { iter: self.delta_cookies.iter() }
     }
 
@@ -374,7 +374,7 @@ impl CookieJar {
     ///     }
     /// }
     /// ```
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             delta_cookies: self.delta_cookies.iter()
                 .chain(self.original_cookies.difference(&self.delta_cookies)),
@@ -540,7 +540,7 @@ impl CookieJar {
     /// assert!(matches!(jar.prefixed(Secure).get("h0st"), None));
     /// ```
     #[inline(always)]
-    pub fn prefixed<'a, P: Prefix>(&'a self, prefix: P) -> PrefixedJar<P, &'a Self> {
+    pub fn prefixed<P: Prefix>(&self, prefix: P) -> PrefixedJar<P, &Self> {
         let _ = prefix;
         PrefixedJar::new(self)
     }
@@ -580,7 +580,7 @@ impl CookieJar {
     /// jar.prefixed_mut(Host).remove("one");
     /// assert!(jar.prefixed(Host).get("one").is_none());
     /// ```
-    pub fn prefixed_mut<'a, P: Prefix>(&'a mut self, prefix: P) -> PrefixedJar<P, &'a mut Self> {
+    pub fn prefixed_mut<P: Prefix>(&mut self, prefix: P) -> PrefixedJar<P, &mut Self> {
         let _ = prefix;
         PrefixedJar::new(self)
     }
@@ -614,13 +614,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = &'a Cookie<'static>;
 
     fn next(&mut self) -> Option<&'a Cookie<'static>> {
-        for cookie in self.delta_cookies.by_ref() {
-            if !cookie.removed {
-                return Some(&*cookie);
-            }
-        }
-
-        None
+        self.delta_cookies.by_ref().find(|&cookie| !cookie.removed).map(|v| v as _)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ impl<'c> CookieStr<'c> {
                     converting indexed str to str! (This is a module invariant.)");
                 &s[i..j]
             },
-            CookieStr::Concrete(ref cstr) => &*cstr,
+            CookieStr::Concrete(ref cstr) => cstr,
         }
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -153,7 +153,7 @@ fn parse_inner<'c>(s: &str, decode: bool) -> Result<Cookie<'c>, ParseError> {
                     v = &v[1..];
                 }
 
-                if !v.chars().all(|d| d.is_digit(10)) {
+                if !v.chars().all(|d| d.is_ascii_digit()) {
                     continue
                 }
 
@@ -164,7 +164,7 @@ fn parse_inner<'c>(s: &str, decode: bool) -> Result<Cookie<'c>, ParseError> {
                 } else {
                     Some(v.parse::<i64>()
                         .map(Duration::seconds)
-                        .unwrap_or_else(|_| Duration::seconds(i64::max_value())))
+                        .unwrap_or_else(|_| Duration::seconds(i64::MAX)))
                 }
             },
             ("domain", Some(d)) if !d.is_empty() => {


### PR DESCRIPTION
During a dependency review we noticed that the cookie crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.