### PR TITLE
Patched the parsing code that uses time and bumped the rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cookie"
 version = "0.18.1"
 authors = ["Sergio Benitez <sb@sergio.bz>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rwf2/cookie-rs"
 readme = "README.md"
@@ -24,7 +24,7 @@ signed = ["dep:hmac", "dep:sha2", "dep:base64", "dep:rand", "dep:subtle"]
 key-expansion = ["dep:sha2", "dep:hkdf"]
 
 [dependencies]
-time = { version = "0.3.45", default-features = false, features = ["std", "parsing", "formatting", "macros"] }
+time = { version = "0.3.52", default-features = false, features = ["std", "parsing", "formatting", "macros"] }
 percent-encoding = { version = "2.0", optional = true }
 
 # dependencies for secure (private/signed) functionality

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -242,7 +242,7 @@ pub(crate) fn parse_cookie<'c, S>(cow: S, decode: bool) -> Result<Cookie<'c>, Pa
 
 pub(crate) fn parse_date(s: &str, format: &impl Parsable) -> Result<OffsetDateTime, time::Error> {
     // Parse. Handle "abbreviated" dates like Chromium. See cookie#162.
-    let mut date = format.parse(s.as_bytes())?;
+    let mut date = format.parse(s.as_bytes(), None)?;
     if let Some(y) = date.year().or_else(|| date.year_last_two().map(|v| v as i32)) {
         let offset = match y {
             0..=69 => 2000,


### PR DESCRIPTION
* Patched the code in src/parse.rs from `format.parse(s.as_bytes())` to `format.parse(s.as_bytes(), None)`by providing the value `None` to the `defaults` argument. 
* Also bumped the rust version from 1.85 to 1.88 because time 0.3.52 requires it.