### PR TITLE
Avoid private time parsing APIs

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -503,6 +503,108 @@ mod tests {
     }
 
     #[test]
+    fn parse_abbreviated_year_edge_cases() {
+        // `01` proves that non-boundary values in the 00-69 range map to 2001-2069.
+        let cookie_str = "foo=bar; expires=Thu, 10-Sep-01 20:00:00 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 2001);
+
+        // `71` proves that non-boundary values in the 70-99 range map to 1970-1999.
+        let cookie_str = "foo=bar; expires=Thu, 10-Sep-71 20:00:00 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 1971);
+
+        // Full years below the cookie-date minimum remain literal years, not short years.
+        let cookie_str = "foo=bar; expires=Thu, 10-Sep-1900 20:00:00 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 1900);
+
+        // Full years that match adjusted short-year results are not adjusted a second time.
+        let cookie_str = "foo=bar; expires=Thu, 10-Sep-1970 20:00:00 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 1970);
+
+        // The upper full year in the 1970-1999 range remains a literal full year.
+        let cookie_str = "foo=bar; expires=Thu, 10-Sep-1999 20:00:00 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 1999);
+
+        // The lower full year in the 2000-2069 range remains a literal full year.
+        let cookie_str = "foo=bar; expires=Thu, 10-Sep-2000 20:00:00 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 2000);
+
+        // A full year just above the short-year mapped range remains a literal full year.
+        let cookie_str = "foo=bar; expires=Thu, 10-Sep-2070 20:00:00 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 2070);
+    }
+
+    #[test]
+    fn parse_abbreviated_years_in_each_supported_format() {
+        // Space-separated dates use FMT1. `69` is the upper edge of the 2000-2069 range.
+        let cookie_str = "foo=bar; expires=Sun, 06 Nov 69 08:49:37 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 2069);
+
+        // FMT1 must also recognize `70` as the lower edge of the 1970-1999 range.
+        let cookie_str = "foo=bar; expires=Sun, 06 Nov 70 08:49:37 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 1970);
+
+        // Long-weekday dash dates use FMT2, the format affected by time-rs/time#793.
+        let cookie_str = "foo=bar; expires=Sunday, 06-Nov-69 08:49:37 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 2069);
+
+        // FMT2 must apply the same cutoff after the format-specific parse succeeds.
+        let cookie_str = "foo=bar; expires=Sunday, 06-Nov-70 08:49:37 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 1970);
+
+        // ANSI-style dates use FMT3. This proves the trailing year is still normalized.
+        let cookie_str = "foo=bar; expires=Sun Nov  6 08:49:37 69";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 2069);
+
+        // FMT3 has the year after the time, but the same cutoff still applies.
+        let cookie_str = "foo=bar; expires=Sun Nov  6 08:49:37 70";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 1970);
+
+        // Short-weekday dash dates with flexible year width use FMT4.
+        let cookie_str = "foo=bar; expires=Sun, 06-Nov-69 08:49:37 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 2069);
+
+        // FMT4 also needs the 70/1970 side of the cutoff because it accepts full years too.
+        let cookie_str = "foo=bar; expires=Sun, 06-Nov-70 08:49:37 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 1970);
+
+        // Full years outside the cutoff range remain literal years after format parsing.
+        let cookie_str = "foo=bar; expires=Wed, 21 Oct 2015 07:28:00 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        let year = cookie.expires_datetime().unwrap().year();
+        assert_eq!(year, 2015);
+    }
+
+    #[test]
     fn parse_variant_date_fmts() {
         let expected = time::macros::datetime!(1994-11-06 8:49:37 UTC);
         let strings = [
@@ -512,6 +614,8 @@ mod tests {
             "foo=bar; expires=06-Nov-94 08:49:37 GMT",
             "foo=bar; expires=Sun Nov  6 08:49:37 1994",
             "foo=bar; expires=Nov  6 08:49:37 1994",
+            // ANSI-style dates place the year after the time; the parser supports this shape.
+            "foo=bar; expires=Sun Nov  6 08:49:37 94",
             "foo=bar; expires=06-Nov-1994 08:49:37 GMT",
         ];
 
@@ -519,6 +623,34 @@ mod tests {
             let cookie = Cookie::parse(cookie_str).unwrap();
             assert_eq!(cookie.expires_datetime(), Some(expected));
         }
+    }
+
+    #[test]
+    fn parse_unsupported_date_formats() {
+        // Long-weekday dash dates are currently accepted only with two-digit years.
+        let cookie_str = "foo=bar; expires=Sunday, 06-Nov-1994 08:49:37 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        assert_eq!(cookie.expires_datetime(), None);
+
+        // Slash separators are not one of the explicit date formats this parser tries.
+        let cookie_str = "foo=bar; expires=Sun, 06/Nov/1994 08:49:37 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        assert_eq!(cookie.expires_datetime(), None);
+
+        // The parser does not search tokens in arbitrary order like the RFC 6265 algorithm.
+        let cookie_str = "foo=bar; expires=08:49:37 06 Nov 1994 GMT";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        assert_eq!(cookie.expires_datetime(), None);
+
+        // GMT-bearing formats require the literal `GMT`; other zone names are unsupported.
+        let cookie_str = "foo=bar; expires=Sun, 06 Nov 1994 08:49:37 UTC";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        assert_eq!(cookie.expires_datetime(), None);
+
+        // The RFC 1123-like date shape requires its trailing `GMT` token.
+        let cookie_str = "foo=bar; expires=Sun, 06 Nov 1994 08:49:37";
+        let cookie = Cookie::parse(cookie_str).unwrap();
+        assert_eq!(cookie.expires_datetime(), None);
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -18,12 +18,20 @@ use time::{
 
 use crate::{Cookie, SameSite, CookieStr};
 
-// The three formats spec'd in http://tools.ietf.org/html/rfc2616#section-3.3.1.
-// Additional ones as encountered in the real world.
+// These are the fixed date shapes accepted for the `Expires` attribute. They cover the HTTP-date
+// forms from RFC 2616 plus additional shapes encountered in the wild.
+//
+// This is not the full RFC 6265 cookie-date tokenizer. That algorithm can extract day, month,
+// year, and time tokens across delimiter and order variations that this parser does not accept.
+// This parser instead tries the known format list below, and applies RFC 6265's two-digit year
+// rule within those formats: 00-69 becomes 2000-2069, and 70-99 becomes 1970-1999.
+// See https://www.rfc-editor.org/rfc/rfc6265#section-5.1.1 and cookie#162.
 pub static FMT1: StaticFormatDescription = format_description!(version = 2,
     "[optional [[weekday repr:short], ]][day] [month repr:short] [year padding:none] [hour]:[minute]:[second] GMT"
 );
 
+// Keep this format to a two-digit year. A long weekday with a full dash-separated year, such as
+// `Sunday, 06-Nov-1994 08:49:37 GMT`, is not accepted by the current compatibility format list.
 pub static FMT2: StaticFormatDescription = format_description!(version = 2,
     "[optional [[weekday], ]][day]-[month repr:short]-[year repr:last_two] [hour]:[minute]:[second] GMT"
 );
@@ -245,7 +253,9 @@ pub(crate) fn parse_cookie<'c, S>(cow: S, decode: bool) -> Result<Cookie<'c>, Pa
 }
 
 pub(crate) fn parse_date(s: &str, format: &StaticFormatDescription) -> Result<OffsetDateTime, time::Error> {
-    // Parse. Handle "abbreviated" dates like Chromium. See cookie#162.
+    // Parse into `Parsed` so short-year formats can be completed before conversion. For example,
+    // FMT2 records `94` as `year_last_two`, and `PrimitiveDateTime` cannot be built until that is
+    // mapped through the cookie#162/RFC 6265 cutoff.
     let mut date = Parsed::new();
     let remaining = date.parse_items(s.as_bytes(), *format)?;
     date.parse_component(remaining, Component::End(modifier::End::default()))?;
@@ -634,6 +644,8 @@ mod tests {
 
     #[test]
     fn parse_unsupported_date_formats() {
+        // A full RFC 6265 tokenizer could accept these by extracting date tokens from broader
+        // delimiter and order shapes. This parser only accepts the explicit formats above.
         // Long-weekday dash dates are currently accepted only with two-digit years.
         let cookie_str = "foo=bar; expires=Sunday, 06-Nov-1994 08:49:37 GMT";
         let cookie = Cookie::parse(cookie_str).unwrap();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,7 +10,11 @@ use std::ascii::AsciiExt;
 #[cfg(feature = "percent-encode")]
 use percent_encoding::percent_decode;
 use time::{PrimitiveDateTime, Duration, OffsetDateTime};
-use time::{parsing::Parsable, macros::format_description, format_description::StaticFormatDescription};
+use time::{
+    format_description::{modifier, Component, StaticFormatDescription},
+    macros::format_description,
+    parsing::Parsed,
+};
 
 use crate::{Cookie, SameSite, CookieStr};
 
@@ -240,9 +244,12 @@ pub(crate) fn parse_cookie<'c, S>(cow: S, decode: bool) -> Result<Cookie<'c>, Pa
     Ok(cookie)
 }
 
-pub(crate) fn parse_date(s: &str, format: &impl Parsable) -> Result<OffsetDateTime, time::Error> {
+pub(crate) fn parse_date(s: &str, format: &StaticFormatDescription) -> Result<OffsetDateTime, time::Error> {
     // Parse. Handle "abbreviated" dates like Chromium. See cookie#162.
-    let mut date = format.parse(s.as_bytes())?;
+    let mut date = Parsed::new();
+    let remaining = date.parse_items(s.as_bytes(), *format)?;
+    date.parse_component(remaining, Component::End(modifier::End::default()))?;
+
     if let Some(y) = date.year().or_else(|| date.year_last_two().map(|v| v as i32)) {
         let offset = match y {
             0..=69 => 2000,


### PR DESCRIPTION
Use documented time parsing entry points for cookie expiration dates so the crate does not rely on internal parsed-field methods from the time crate.

This replaces #256 with an approach that tests, documents and uses the public method instead of the private one.